### PR TITLE
Fix account enumeration via signup flow

### DIFF
--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -1257,6 +1257,8 @@ ACCOUNT_USER_MODEL_USERNAME_FIELD = None
 # account_email_verification_sent (not to the login page), so ACCOUNT_SIGNUP_REDIRECT_URL
 # below is only reached when the user is already verified (e.g. social auth signup).
 ACCOUNT_EMAIL_VERIFICATION = 'mandatory'
+# Prevent account enumeration by showing identical behavior for existing and new emails
+ACCOUNT_PREVENT_ENUMERATION = 'strict'
 # Prefer Jinja2 templates for django-allauth
 ACCOUNT_TEMPLATE_EXTENSION = 'jinja'
 ACCOUNT_ADAPTER = 'eventyay.eventyay_common.adapter.CustomAccountAdapter'


### PR DESCRIPTION
Override allauth's email_confirmation_sent.txt template to remove the email address from the flash message. The default template reveals whether an email is registered by showing "Confirmation email sent to user@example.com" - this allows attackers to enumerate valid accounts.

The fix uses a generic message that doesn't disclose the email.

Fixes #4016

## Summary by Sourcery

Prevent account enumeration via signup email confirmation messages by updating template configuration and overriding the confirmation message template.

Bug Fixes:
- Hide specific email addresses in signup confirmation flashes to prevent revealing whether an email is registered.

Enhancements:
- Add base templates directory to Django template search paths to support custom account messaging templates.