### PR TITLE
chore: social-plugin-version-bump

### DIFF
--- a/app/uv.lock
+++ b/app/uv.lock
@@ -1183,7 +1183,7 @@ source = { git = "https://github.com/fossasia/eventyay-paypal.git?rev=main#a6d9c
 [[package]]
 name = "eventyay-socialmedia"
 version = "1.0.0"
-source = { git = "https://github.com/fossasia/eventyay-socialmedia.git?rev=main#7bcb3892eda14b63d6eb981b707125bf529c465c" }
+source = { git = "https://github.com/fossasia/eventyay-socialmedia.git?rev=main#485983f00c3d8c97360d82c88013a5337a48cdbe" }
 
 [[package]]
 name = "eventyay-stripe"


### PR DESCRIPTION
Updates the social media plugin commit hash in uv lock.

## Summary by Sourcery

Chores:
- Bump social media plugin commit hash in uv.lock dependency lockfile.