### PR TITLE
fix : Make PDF ticket output a core feature and remove it from plugins

### DIFF
--- a/app/eventyay/api/urls.py
+++ b/app/eventyay/api/urls.py
@@ -133,6 +133,8 @@ for app in apps.get_app_configs():
         if importlib.util.find_spec(app.name + '.urls'):
             importlib.import_module(app.name + '.urls')
 
+importlib.import_module('eventyay.plugins.ticketoutputpdf.urls')
+
 urlpatterns = [
     path('', include(router.urls)),
     path('organizers/<orgslug:organizer>/', include(orga_router.urls)),

--- a/app/eventyay/control/views/event.py
+++ b/app/eventyay/control/views/event.py
@@ -1573,14 +1573,6 @@ class QuickSetupView(FormView):
     def form_valid(self, form):
         plugins_active = self.request.event.get_plugins()
         if form.cleaned_data['ticket_download']:
-            if 'eventyay.plugins.ticketoutputpdf' not in plugins_active:
-                self.request.event.log_action(
-                    'eventyay.event.plugins.enabled',
-                    user=self.request.user,
-                    data={'plugin': 'eventyay.plugins.ticketoutputpdf'},
-                )
-                plugins_active.append('eventyay.plugins.ticketoutputpdf')
-
             self.request.event.settings.ticket_download = True
             self.request.event.settings.ticketoutput_pdf__enabled = True
 

--- a/app/eventyay/eventyay_common/views/event.py
+++ b/app/eventyay/eventyay_common/views/event.py
@@ -469,7 +469,6 @@ class EventCreateView(TemplateView):
             default_plugins = list(settings.EVENTYAY_PLUGINS_DEFAULT)
 
             ticketing_plugins = [
-                'eventyay.plugins.ticketoutputpdf',
                 'eventyay.plugins.banktransfer',
                 'eventyay.plugins.manualpayment',
             ]

--- a/app/eventyay/multidomain/maindomain_urlconf.py
+++ b/app/eventyay/multidomain/maindomain_urlconf.py
@@ -23,6 +23,7 @@ from eventyay.presale.views.startpage import (
 )
 
 from .views import AnonymousInviteRedirectView, VideoAssetView, VideoSPAView
+from eventyay.plugins.ticketoutputpdf import urls as ticketoutputpdf_urls
 
 
 logger = logging.getLogger(__name__)
@@ -83,7 +84,6 @@ for app in apps.get_app_configs():
             except (ImportError, AttributeError, TypeError):
                 logger.exception('Error loading plugin URLs for %s', app.name)
 
-# Manually register ticketoutputpdf since it is no longer a plugin
 from eventyay.plugins.ticketoutputpdf import urls as ticketoutputpdf_urls
 if hasattr(ticketoutputpdf_urls, 'urlpatterns'):
     raw_plugin_patterns.append(path('', include((ticketoutputpdf_urls.urlpatterns, 'ticketoutputpdf'))))

--- a/app/eventyay/multidomain/maindomain_urlconf.py
+++ b/app/eventyay/multidomain/maindomain_urlconf.py
@@ -83,6 +83,11 @@ for app in apps.get_app_configs():
             except (ImportError, AttributeError, TypeError):
                 logger.exception('Error loading plugin URLs for %s', app.name)
 
+# Manually register ticketoutputpdf since it is no longer a plugin
+from eventyay.plugins.ticketoutputpdf import urls as ticketoutputpdf_urls
+if hasattr(ticketoutputpdf_urls, 'urlpatterns'):
+    raw_plugin_patterns.append(path('', include((ticketoutputpdf_urls.urlpatterns, 'ticketoutputpdf'))))
+
 
 plugin_patterns = [path('', include((raw_plugin_patterns, 'plugins')))]
 

--- a/app/eventyay/multidomain/maindomain_urlconf.py
+++ b/app/eventyay/multidomain/maindomain_urlconf.py
@@ -84,7 +84,6 @@ for app in apps.get_app_configs():
             except (ImportError, AttributeError, TypeError):
                 logger.exception('Error loading plugin URLs for %s', app.name)
 
-from eventyay.plugins.ticketoutputpdf import urls as ticketoutputpdf_urls
 if hasattr(ticketoutputpdf_urls, 'urlpatterns'):
     raw_plugin_patterns.append(path('', include((ticketoutputpdf_urls.urlpatterns, 'ticketoutputpdf'))))
 

--- a/app/eventyay/plugins/ticketoutputpdf/apps.py
+++ b/app/eventyay/plugins/ticketoutputpdf/apps.py
@@ -9,12 +9,6 @@ class TicketOutputPdfApp(AppConfig):
     name = 'eventyay.plugins.ticketoutputpdf'
     verbose_name = _('PDF ticket output')
 
-    class EventyayPluginMeta:
-        name = _('PDF ticket output')
-        version = version
-        category = 'FORMAT'
-        featured = True
-        description = _('This plugin allows you to print out tickets as PDF files')
 
     def ready(self):
         from . import signals  # NOQA


### PR DESCRIPTION
Close: #4678

https://github.com/user-attachments/assets/eea499ee-b869-4b99-a8fb-9f3964b0af37

## Summary by Sourcery

Make PDF ticket output a core, always-available feature instead of a dynamically enabled plugin.

New Features:
- Always enable PDF ticket output routing and API endpoints without relying on plugin activation.

Enhancements:
- Simplify event ticket download handling by removing dynamic activation of the PDF ticket output plugin metadata and default plugin configuration.