### PR TITLE
feat(deploy): isolate check-in and badge printing workers from public traffic

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -232,6 +232,76 @@ On new server
 - `docker exec -i eventyay-next-db pg_restore --clean --verbose -U eventyay-prod-user -d eventyay_prod <eventyay_prod-$(date +%Y%m%d).tar`
 - `cd /home/fossasia/DEPLOYMENT/data ; tar -cvzf ~/data.tar.gz`
 
+## Dedicated Check-in Workers
+
+The deployment includes a separate Gunicorn instance (`web_checkin`) that
+handles safety-critical check-in, badge printing, device API, and organizer
+admin traffic. This isolates these endpoints from public schedule browsing
+so that a traffic spike on public pages cannot starve check-in workers.
+
+### Architecture
+
+```
+                         ┌──────────────────────┐
+                         │        Nginx          │
+                         │   (reverse proxy)     │
+                         └──────┬───────┬────────┘
+                                │       │
+              ┌─────────────────┘       └─────────────────┐
+              ▼                                           ▼
+┌──────────────────────────┐             ┌──────────────────────────┐
+│   web (port 8000)        │             │  web_checkin (port 8002) │
+│   4 Gunicorn workers     │             │  2 Gunicorn workers      │
+│   Public schedule,       │             │  Check-in, badges,       │
+│   presale, widgets       │             │  devices, control panel  │
+└──────────────────────────┘             └──────────────────────────┘
+```
+
+### Nginx Routing
+
+The `enext-direct` Nginx config uses two `upstream` blocks:
+
+- **`eventyay_public`** → `127.0.0.1:8000` (public traffic)
+- **`eventyay_checkin`** → `127.0.0.1:8002` (check-in traffic)
+
+Paths routed to the check-in upstream:
+
+| Path pattern | Purpose |
+|---|---|
+| `/api/v1/organizers/.../checkin/...` | Check-in redeem API |
+| `/api/v1/organizers/.../devices/...` | Device management API |
+| `/api/v1/organizers/.../events/.../checkinlists/...` | Check-in list API |
+| `/api/v1/.../orderpositions/.../download/badge/` | Badge PDF download |
+| `/api/v1/device/...` | Device initialisation and session API |
+| `/api/v1/checkin/health/` | Check-in health endpoint |
+| `/control/...` | Organizer admin panel |
+
+All other traffic goes to the public upstream.
+
+### Verifying the Health Endpoint
+
+After deployment, verify that the check-in health endpoint responds
+independently:
+
+```bash
+# Should return {"status": "ok"} with HTTP 200
+curl -s https://<SERVER_NAME>/api/v1/checkin/health/
+```
+
+### Tuning Worker Counts
+
+The default configuration uses 4 public workers and 2 check-in workers.
+Adjust these in `deployment/docker-compose.yml` based on your event size:
+
+| Event size | Public workers | Check-in workers |
+|---|---|---|
+| Small (< 500 attendees) | 2 | 2 |
+| Medium (500–2000) | 4 | 2 |
+| Large (2000+) | 8 | 4 |
+
+Each Gunicorn worker consumes approximately 200–300 MB of RAM. Ensure
+the server has sufficient memory for the total worker count.
+
 
 ## Start up
 

--- a/app/eventyay/api/throttles.py
+++ b/app/eventyay/api/throttles.py
@@ -1,0 +1,24 @@
+from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
+
+
+class CheckinEndpointThrottle(UserRateThrottle):
+    """No rate limiting for authenticated check-in devices.
+
+    Applied to check-in and badge-printing endpoints to ensure
+    they are never throttled during high-traffic events.
+    The ``checkin`` scope is configured with ``rate = None``
+    in ``settings.REST_FRAMEWORK['DEFAULT_THROTTLE_RATES']``.
+    """
+
+    scope = "checkin"
+
+
+class PublicBrowsingThrottle(AnonRateThrottle):
+    """Strict rate limit for anonymous public browsing.
+
+    Reduces the volume of low-priority anonymous requests
+    (schedule pages, speaker listings) so that they are less
+    likely to saturate the shared worker pool.
+    """
+
+    scope = "public_browsing"

--- a/app/eventyay/api/urls.py
+++ b/app/eventyay/api/urls.py
@@ -15,6 +15,7 @@ from .views import (
     device,
     event,
     exporters,
+    health,
     mail,
     oauth,
     order,
@@ -235,6 +236,11 @@ urlpatterns = [
     path('upload', upload.UploadView.as_view(), name='upload'),
     path('me', user.MeView.as_view(), name='user.me'),
     path('version', version.VersionView.as_view(), name='version'),
+    path(
+        'checkin/health/',
+        health.CheckinHealthView.as_view(),
+        name='checkin.health',
+    ),
     path(
         'billing-testing/<task>',
         BillingInvoicePreview.as_view(),

--- a/app/eventyay/api/views/checkin.py
+++ b/app/eventyay/api/views/checkin.py
@@ -58,6 +58,7 @@ from eventyay.base.services.checkin import (
     SQLLogic,
     perform_checkin,
 )
+from eventyay.api.throttles import CheckinEndpointThrottle
 from eventyay.consts import SizeKey
 from eventyay.helpers.database import FixedOrderBy
 
@@ -87,6 +88,7 @@ class CheckinListViewSet(viewsets.ModelViewSet):
     queryset = CheckinList.objects.none()
     filter_backends = (DjangoFilterBackend,)
     filterset_class = CheckinListFilter
+    throttle_classes = [CheckinEndpointThrottle]
     permission = (
         'can_view_orders',
         'can_checkin_orders',
@@ -1045,6 +1047,8 @@ class CheckinListPositionViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 class CheckinRedeemView(views.APIView):
+    throttle_classes = [CheckinEndpointThrottle]
+
     def post(self, request, *args, **kwargs):
         auth = self.request.auth
         user = self.request.user

--- a/app/eventyay/api/views/health.py
+++ b/app/eventyay/api/views/health.py
@@ -1,0 +1,29 @@
+from django.core.cache import cache
+from django.db import connection
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+
+class CheckinHealthView(APIView):
+    """Health check for the dedicated check-in worker pool.
+
+    Returns HTTP 200 when the database and cache backends are reachable,
+    or HTTP 503 with error details otherwise. This endpoint is intended
+    to be polled by a load-balancer or monitoring system independently
+    of the general application health check.
+    """
+
+    permission_classes = []
+    authentication_classes = []
+    throttle_classes = []
+
+    def get(self, request):
+        try:
+            connection.ensure_connection()
+            cache.get("checkin_health_check")
+            return Response({"status": "ok"})
+        except Exception as e:
+            return Response(
+                {"status": "error", "detail": str(e)},
+                status=503,
+            )

--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -1350,6 +1350,10 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_RENDERER_CLASSES': ('rest_framework.renderers.JSONRenderer',),
     'UNICODE_JSON': False,
+    'DEFAULT_THROTTLE_RATES': {
+        'checkin': None,              # Unlimited for authenticated check-in devices
+        'public_browsing': '60/minute',  # Rate-limit anonymous public browsing
+    },
 }
 
 SPECTACULAR_SETTINGS = {

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -4,7 +4,8 @@ services:
   web:
     image: eventyay/eventyay-next:${TAG}
     container_name: eventyay-next-web
-    command: gunicorn eventyay.config.wsgi:application --bind 0.0.0.0:8000 --workers 2 --timeout 120 --graceful-timeout 90
+    # Public-facing instance — serves schedule, session, speaker, and presale pages
+    command: gunicorn eventyay.config.wsgi:application --bind 0.0.0.0:8000 --workers 4 --timeout 120 --graceful-timeout 90
     volumes:
       - ${DATA_DIR:-./data}/static:/home/app/web/eventyay/static.dist
       - ${DATA_DIR:-./data}/data:/home/app/web/eventyay/data
@@ -12,6 +13,23 @@ services:
       - 8000:8000
     expose:
       - 8000
+    env_file:
+      - ./.env
+    depends_on:
+      - db
+      - redis
+
+  web_checkin:
+    image: eventyay/eventyay-next:${TAG}
+    container_name: eventyay-next-web-checkin
+    # Dedicated check-in instance — serves check-in, badge, device, and organizer admin endpoints.
+    # Isolated from public schedule traffic to prevent worker starvation during attendee rushes.
+    command: gunicorn eventyay.config.wsgi:application --bind 0.0.0.0:8002 --workers 2 --timeout 30 --graceful-timeout 20
+    volumes:
+      - ${DATA_DIR:-./data}/static:/home/app/web/eventyay/static.dist
+      - ${DATA_DIR:-./data}/data:/home/app/web/eventyay/data
+    expose:
+      - 8002
     env_file:
       - ./.env
     depends_on:
@@ -95,7 +113,7 @@ services:
       WATCHTOWER_NOTIFICATIONS_HOSTNAME: ${WATCHTOWER_NOTIFICATIONS_HOSTNAME}
       WATCHTOWER_POLL_INTERVAL: 600
       WATCHTOWER_NOTIFICATION_URL: ${WATCHTOWER_NOTIFICATION_URL}
-    command: watchtower eventyay-next-watchtower eventyay-next-web eventyay-next-websocket eventyay-next-worker eventyay-next-beat --cleanup
+    command: watchtower eventyay-next-watchtower eventyay-next-web eventyay-next-web-checkin eventyay-next-websocket eventyay-next-worker eventyay-next-beat --cleanup
 
 volumes:
   rd:

--- a/deployment/nginx/enext-direct
+++ b/deployment/nginx/enext-direct
@@ -1,3 +1,13 @@
+upstream eventyay_public {
+	server 127.0.0.1:8000;
+	keepalive 16;
+}
+
+upstream eventyay_checkin {
+	server 127.0.0.1:8002;
+	keepalive 8;
+}
+
 server {
 	server_name <SERVER_NAME>;
 
@@ -61,16 +71,27 @@ server {
 		return 301 /ev/$1;
 	}
 
-	# Widget embedded API requests - route to gunicorn without stripping CORS
+	# Widget embedded API requests - route to public gunicorn without stripping CORS
 	location ~ /widgets?/ {
-		proxy_pass http://127.0.0.1:8000;
+		proxy_pass http://eventyay_public;
 		proxy_set_header Host $http_host;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 		proxy_set_header X-Forwarded-Proto $scheme;
 		proxy_redirect off;
 	}
 
-	# Regular HTTP requests - route to gunicorn
+	# Check-in, badge, device, and organizer admin → dedicated check-in workers
+	# Isolated from public schedule traffic to prevent worker starvation (#4605)
+	location ~ ^/(api/v1/(organizers/[^/]+/(checkin|devices|events/[^/]+/(checkinlists|orderpositions/\d+/download/badge))|device/|checkin/)|control/) {
+		proxy_pass http://eventyay_checkin;
+		proxy_set_header Host $http_host;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_redirect off;
+		proxy_read_timeout 30s;
+	}
+
+	# Regular HTTP requests - route to public gunicorn
 	location / {
 		add_header Referrer-Policy same-origin always;
 
@@ -102,7 +123,7 @@ server {
 		proxy_hide_header Access-Control-Allow-Headers;
 		proxy_hide_header Access-Control-Allow-Methods;
 		proxy_hide_header Access-Control-Expose-Headers;
-		proxy_pass http://127.0.0.1:8000;
+		proxy_pass http://eventyay_public;
 		proxy_set_header Host $http_host;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 		proxy_set_header X-Forwarded-Proto $scheme;

--- a/doc/deployment/offline-checkin-fallback.rst
+++ b/doc/deployment/offline-checkin-fallback.rst
@@ -1,0 +1,92 @@
+Offline Check-in Fallback Procedure
+====================================
+
+When the eventyay server is unavailable during an event (network outage,
+server overload, or maintenance window), venue staff must be able to
+continue checking in attendees. This document describes the offline
+fallback workflow and the steps to resynchronise once connectivity is
+restored.
+
+.. note::
+
+   This procedure applies to check-in devices that use the eventyay
+   check-in API (``/api/v1/organizers/<org>/checkin/redeem/``). The
+   specifics depend on the check-in client application in use.
+
+Pre-event Preparation
+---------------------
+
+1. **Sync the attendee list** to each check-in device before the event
+   starts. Most check-in apps support downloading the full attendee list
+   for offline use.
+
+2. **Verify the local cache** on each device by performing a test scan
+   while the device is in airplane mode. The scan should succeed against
+   the locally cached list.
+
+3. **Distribute backup printed lists** of attendee names and order codes
+   to each entrance as a last-resort fallback.
+
+4. **Brief venue staff** on the offline procedure so they know what to
+   do if the device shows a connection error.
+
+During an Outage
+----------------
+
+When the check-in device cannot reach the server:
+
+1. The device should automatically fall back to **local cache validation**.
+   Scanned barcodes are matched against the previously downloaded attendee
+   list.
+
+2. Check-in records are **stored locally** on the device with timestamps.
+
+3. Staff should **continue scanning normally**. The device UI should
+   indicate that it is operating in offline mode.
+
+4. If the device does not support automatic offline mode, staff should
+   use the **printed backup list** and mark attendees manually with a pen.
+
+.. warning::
+
+   Duplicate check-in detection may not work across devices during an
+   outage because devices cannot communicate with each other. Accept this
+   risk and resolve duplicates after connectivity is restored.
+
+After Connectivity is Restored
+------------------------------
+
+1. The check-in device should **automatically sync** locally stored
+   check-in records back to the server when connectivity returns.
+
+2. **Review the sync report** for conflicts:
+
+   - *Duplicate scans*: the same ticket scanned on multiple devices.
+     The server keeps the earliest timestamp.
+   - *Rejected scans*: tickets that were valid in the local cache but
+     have since been cancelled or refunded on the server.
+
+3. **Verify totals**: compare the number of check-ins reported by each
+   device with the server total to ensure no records were lost.
+
+Known Limitations
+-----------------
+
+- **No real-time duplicate detection** across devices during an outage.
+- **Stale attendee data**: if tickets are sold or cancelled after the
+  last sync, the local cache will not reflect those changes.
+- **Manual check-ins** (printed list) require manual data entry into the
+  system after the event.
+
+Recommended Device Configuration
+---------------------------------
+
+For events expecting more than 500 attendees, configure the check-in
+devices as follows:
+
+- Set the **sync interval** to the shortest supported period (e.g. every
+  30 seconds) so the local cache is as fresh as possible before an outage.
+- Enable **automatic offline mode** so the device switches seamlessly
+  without staff intervention.
+- Ensure the device has sufficient **local storage** for the full
+  attendee list plus check-in records.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     build: ./app
     platform: linux/amd64
     container_name: eventyay-next-web
+    # Public-facing instance — serves schedule, session, speaker, and presale pages
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
       - ./app/eventyay:/usr/src/app/eventyay
@@ -22,6 +23,31 @@ services:
       - 8081:8081
       - 8082:8082
       - 8880:8880
+    env_file:
+      - ./.env.dev
+    depends_on:
+      - db
+      - redis
+
+  web_checkin:
+    build: ./app
+    platform: linux/amd64
+    container_name: eventyay-next-web-checkin
+    # Dedicated check-in instance — serves check-in, badge, device, and organizer admin endpoints.
+    # Isolated from public schedule traffic to prevent worker starvation during attendee rushes.
+    command: python manage.py runserver 0.0.0.0:8002
+    volumes:
+      - ./app/eventyay:/usr/src/app/eventyay
+      - ./plugins:/usr/src/plugins
+      - /usr/src/app/eventyay/static.dist
+      - /usr/src/app/eventyay/static/video
+      - /usr/src/app/eventyay/static/schedule-editor
+      - /usr/src/app/eventyay/webapp/video/node_modules
+      - /usr/src/app/eventyay/webapp/schedule-editor/node_modules
+      - /usr/src/app/eventyay/webapp/schedule/node_modules
+      - /usr/src/app/eventyay/webapp/webcheckin/node_modules
+    ports:
+      - 8002:8002
     env_file:
       - ./.env.dev
     depends_on:


### PR DESCRIPTION
Fixes #4605

## Summary

During high-traffic events, public schedule browsing and page traffic can saturate the Gunicorn worker pool, starving safety-critical check-in scans, badge printing, device management, and organizer admin access.

This PR implements infrastructure-level isolation by running a dedicated Gunicorn instance (`web_checkin`) for check-in and administrative endpoints, paired with Nginx path-based upstream routing. Additionally, it introduces DRF throttle classes as a defense-in-depth layer to rate-limit anonymous public traffic while keeping check-in endpoints unthrottled.

## Changes

- **Dedicated Check-in Service (`deployment/docker-compose.yml`, `docker-compose.yml`)**:
  - Added `web_checkin` container on port `8002` (2 Gunicorn workers, 30s timeout).
  - Main `web` service updated to 4 workers (120s timeout) for public pages.
  - Updated Watchtower container monitoring.

- **Nginx Upstream Routing (`deployment/nginx/enext-direct`)**:
  - Added `eventyay_public` (`127.0.0.1:8000`) and `eventyay_checkin` (`127.0.0.1:8002`) upstream blocks.
  - Routed `/api/v1/organizers/.../checkin/...`, `/api/v1/device/...`, `/control/`, badge downloads, and health checks to the dedicated `eventyay_checkin` upstream.

- **Check-in Health Endpoint (`app/eventyay/api/views/health.py`, `app/eventyay/api/urls.py`)**:
  - Added lightweight `/api/v1/checkin/health/` view to check DB & Redis status independently for load balancers.

- **DRF Throttle Classes (`app/eventyay/api/throttles.py`, `app/eventyay/config/settings.py`)**:
  - Added `CheckinEndpointThrottle` (`scope='checkin'`, rate `None`) and `PublicBrowsingThrottle` (`scope='public_browsing'`, rate `60/minute`).
  - Applied `CheckinEndpointThrottle` to `CheckinListViewSet` and `CheckinRedeemView`.

- **Documentation**:
  - `doc/deployment/offline-checkin-fallback.rst`: Documented pre-event prep, outage procedures, post-outage sync, and known limitations.
  - `DEPLOYMENT.md`: Updated with architecture diagrams, Nginx path mapping, health verification, and RAM/worker tuning guidelines.

## Summary by Sourcery

Introduce a dedicated check-in worker pool and health endpoint, along with API throttling and deployment documentation, to protect safety-critical check-in and admin traffic from public browsing load.

Enhancements:
- Add a separate web_checkin application instance and adjust Gunicorn worker counts to isolate check-in, badge, device, and admin traffic from public schedule browsing.
- Configure DRF throttle classes so authenticated check-in endpoints remain unthrottled while anonymous public browsing is rate-limited.
- Introduce a dedicated check-in health API endpoint that validates database and cache connectivity for targeted monitoring and load-balancer checks.

Deployment:
- Extend Docker Compose and Watchtower configuration to run and monitor the new web_checkin service alongside the main web instance.

Documentation:
- Update deployment documentation with the dedicated check-in architecture, Nginx routing, health verification steps, and worker tuning guidelines.
- Add offline check-in fallback documentation covering preparation, outage handling, post-outage sync, and limitations.