### PR TITLE
fix(schedule): restore multimd-table under markdown-it 15

### DIFF
--- a/app/eventyay/webapp/schedule/src/utils/eventyayRichText.js
+++ b/app/eventyay/webapp/schedule/src/utils/eventyayRichText.js
@@ -7,6 +7,17 @@ import MarkdownIt from 'markdown-it'
 import createDOMPurify from 'dompurify'
 import multimdTable from 'markdown-it-multimd-table'
 
+/**
+ * markdown-it v15 removed legacy md.utils.assign (use Object.assign).
+ * markdown-it-multimd-table still calls md.utils.assign during .use().
+ */
+function multimdTableCompat (md, options) {
+	if (typeof md.utils.assign !== 'function') {
+		md.utils.assign = Object.assign
+	}
+	return multimdTable(md, options)
+}
+
 /** @type {string[]} */
 export const EVENTYAY_RICH_TEXT_ALLOWED_TAGS = [
 	'a',
@@ -66,13 +77,13 @@ const markdownItWithHtml = new MarkdownIt({
 	html: true,
 	linkify: true,
 	breaks: true,
-}).use(multimdTable)
+}).use(multimdTableCompat)
 
 const markdownItNoHtml = new MarkdownIt({
 	html: false,
 	linkify: true,
 	breaks: true,
-}).use(multimdTable)
+}).use(multimdTableCompat)
 
 const PURIFY_CONFIG = {
 	ALLOWED_TAGS: EVENTYAY_RICH_TEXT_ALLOWED_TAGS,


### PR DESCRIPTION
## Summary
- Video production builds crash with `e.utils.assign is not a function` because the router pulls schedule rich text, which loads `markdown-it-multimd-table`.
- `markdown-it` 15 removed legacy `md.utils.assign`; wrap multimd-table with a small compat shim that falls back to `Object.assign` instead of pinning markdown-it.

## Test plan
- [x] With `EVY_NPM_DEV=0`, rebuild video assets (`make npminstall` / collectstatic) and open an event video page
- [x] Confirm console no longer shows `utils.assign is not a function` from `vendor-markdown` / `router`
- [x] Confirm schedule session/talk rich text (including markdown tables) still renders

## Summary by Sourcery

Bug Fixes:
- Prevent crashes in video event pages caused by markdown-it-multimd-table calling the removed md.utils.assign function under markdown-it v15.