### PR TITLE
chore: update uv.lock for exhibition

### DIFF
--- a/app/uv.lock
+++ b/app/uv.lock
@@ -1698,7 +1698,7 @@ wheels = [
 [[package]]
 name = "exhibition"
 version = "1.0.0"
-source = { git = "https://github.com/fossasia/eventyay-exhibition.git?rev=main#680a466196c9fcc362733ff8965d3042bedf8898" }
+source = { git = "https://github.com/fossasia/eventyay-exhibition.git?rev=main#27467b2148717a5685330e047f540f1551321c06" }
 
 [[package]]
 name = "faker"


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Regenerate app/uv.lock to capture updated dependency resolutions.