### PR TITLE
Reduce notifications polling frequency and add visibility/jitter guards

### DIFF
--- a/app/eventyay/webapp/video/src/main.js
+++ b/app/eventyay/webapp/video/src/main.js
@@ -138,7 +138,16 @@ async function init({ token, inviteToken }) {
     setInterval(() => store.commit('updateNow'), 60000)
   }, 60000 - (Date.now() % 60000))
 
-  setInterval(() => store.dispatch('notifications/pollExternals'), 1000)
+  function pollExternalsIfVisible() {
+    if (!document.hidden) {
+      store.dispatch('notifications/pollExternals')
+    }
+  }
+  const pollExternalsJitter = Math.random() * 15000
+  setTimeout(() => {
+    setInterval(pollExternalsIfVisible, 30000)
+  }, pollExternalsJitter)
+
   window.__venueless__release = RELEASE
 
   window.addEventListener('beforeinstallprompt', function (event) {


### PR DESCRIPTION
Fixes #4600

This PR reduces the notification polling frequency, pauses polling on hidden tabs, and adds startup jitter to prevent multiple clients from polling in sync.

## Root Cause

* `app/eventyay/webapp/video/src/main.js` polled `notifications/pollExternals` unconditionally every 1 second, including while the tab was hidden.
* There was no visibility guard, startup jitter, or backoff mechanism, which could cause synchronized polling bursts across multiple clients.
* During investigation, `pollExternals` in `store/notifications.js` was found to make **no network request**. It only reads `Notification.permission` and `localStorage`, both synchronous local operations. Therefore, the issue's premise of "500 req/s to a single endpoint" does not match the current codebase. This was flagged on the issue for clarification: [link to your comment].

## Changes
- `main.js`: increased poll interval from 1s to 30s
- Added a `document.hidden` visibility guard so polling pauses on background tabs
- Added 0-15s random startup jitter to de-synchronize multiple clients

## Acceptance criteria (from #4600)
- [x] Called no more frequently than every 30 seconds — verified via console timing
- [x] No polling while tab is hidden — verified by backgrounding tab 45s+, no fires logged
- [x] Startup jitter prevents synchronized bursts — verified across multiple reloads, offset varies
- [ ] 401/403 stops polling — **N/A**: no network call exists in this function to receive a response from
- [ ] >95% traffic reduction load test — **N/A**: no endpoint traffic exists to measure a reduction against

## Testing
- Reproduced the 1s polling via console logging showing continuous fires at ~1000ms intervals, including while the tab was backgrounded. 
- After the fix, confirmed: ~30s gaps between fires, zero fires while tab hidden, and first-fire timestamp varying across page reloads (jitter working).

## Screenshot 
- before - in ~20sec
<img width="473" height="832" alt="2026-08-11-023355_hyprshot" src="https://github.com/user-attachments/assets/963ef2b0-8495-4e38-9d90-5220fd5ff44a" />

- after - first 2 in ~1min, backgrounding for ~2min, last 2 in ~1min
<img width="404" height="390" alt="2026-08-11-023732_hyprshot" src="https://github.com/user-attachments/assets/262f7779-ad79-44c0-9a50-a9a748966aa8" />

## Summary by Sourcery

Reduce frequency and add guards for external notifications polling in the video webapp to lower load and avoid background-tab and synchronized polling issues.

Enhancements:
- Increase notifications polling interval and add startup jitter to desynchronize clients.
- Pause notifications polling when the document is hidden to avoid background-tab activity.