### PR TITLE
Fix: Subclass `TeamPermissionError` from Django's `PermissionDenied`

### DIFF
--- a/app/eventyay/base/models/organizer.py
+++ b/app/eventyay/base/models/organizer.py
@@ -6,6 +6,7 @@ from urllib.parse import urlencode
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from django.conf import settings
+from django.core.exceptions import PermissionDenied
 from django.core.validators import MinLengthValidator, RegexValidator
 from django.db import models, transaction
 from django.db.models import Exists, OuterRef, Q
@@ -37,7 +38,7 @@ from .auth import User
 logger = logging.getLogger(__name__)
 
 
-class TeamPermissionError(Exception):
+class TeamPermissionError(PermissionDenied):
     """Raised when team access permission checks fail to preserve administrator access."""
 
     pass


### PR DESCRIPTION
This PR updates `TeamPermissionError` to inherit from Django's `PermissionDenied` instead of a generic `Exception`. 

