### PR TITLE
feat(api): allow Check-In Staff devices to sync orders for offline check-in

### DIFF
--- a/app/eventyay/api/auth/devicesecurity.py
+++ b/app/eventyay/api/auth/devicesecurity.py
@@ -97,11 +97,23 @@ _CHECKIN_CORE_ALLOWLIST = (
 # Badge Station (kiosk): scan, check-in, search, badge download.
 _BADGE_STATION_ALLOWLIST = _CHECKIN_CORE_ALLOWLIST
 
-# Check-In Staff: live registration (product list, order create, mark paid) — may move to embedded widget later.
+# Check-In Staff: live registration + offline sync (orders delta, revoked secrets, badge layouts).
 _CHECKIN_STAFF_EXTRA_ALLOWLIST = (
     ('GET', 'api-v1:product-list'),
     ('POST', 'api-v1:order-list'),
     ('POST', 'api-v1:order-mark-paid'),
+    # Offline sync: incremental orders + revocation list (Badge Station / NoSync stays excluded).
+    ('GET', 'api-v1:order-list'),
+    ('GET', 'api-v1:revokedsecrets-list'),
+    # Offline badge print: layout JSON synced separately from per-attendee pdf_data.
+    ('GET', 'api-v1:badgelayout-list'),
+    ('GET', 'api-v1:badgelayout-detail'),
+    ('GET', 'api-v1:badgelayouts-list'),
+    ('GET', 'api-v1:badgelayouts-detail'),
+    ('GET', 'api-v1:badgeproduct-list'),
+    ('GET', 'api-v1:badgeproduct-detail'),
+    ('GET', 'api-v1:badgeitems-list'),
+    ('GET', 'api-v1:badgeitems-detail'),
 )
 
 
@@ -109,7 +121,8 @@ class EventyayCheckinSecurityProfile(AllowListSecurityProfile):
     identifier = 'eventyay_checkin'
     verbose_name = _('Check-In Staff')
     usage_description = _(
-        'Ticket check-in, attendee search and edits, live registration, and badge printing.'
+        'Ticket check-in, attendee search and edits, live registration, badge printing, '
+        'and offline sync of orders, revoked secrets, and badge layouts.'
     )
     includes_profiles = ('eventyay_checkin_online_kiosk',)
     allowlist = _CHECKIN_CORE_ALLOWLIST + _CHECKIN_STAFF_EXTRA_ALLOWLIST
@@ -119,7 +132,8 @@ class EventyayCheckinNoSyncSecurityProfile(AllowListSecurityProfile):
     identifier = 'eventyay_checkin_online_kiosk'
     verbose_name = _('Badge Station (kiosk)')
     usage_description = _(
-        'Kiosk badge printing: scan tickets, check in attendees, and print badges. No live registration.'
+        'Kiosk badge printing: scan tickets, check in attendees, and print badges. '
+        'Online only — no order sync, revoked-secret sync, or live registration.'
     )
     allowlist = _BADGE_STATION_ALLOWLIST
 

--- a/app/eventyay/api/serializers/order.py
+++ b/app/eventyay/api/serializers/order.py
@@ -460,10 +460,13 @@ class OrderPositionSerializer(I18nAwareModelSerializer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         request = self.context.get('request')
+        eventpermset = getattr(request, 'eventpermset', None) if request else None
+        # If eventpermset is not available yet (nested field bind), keep pdf_data;
+        # OrderSerializer / the view will drop it when unauthorized or not requested.
         if (
             not request
-            or not self.context['request'].query_params.get('pdf_data', 'false') == 'true'
-            or 'can_view_orders' not in request.eventpermset
+            or request.query_params.get('pdf_data', 'false') != 'true'
+            or (eventpermset is not None and 'can_view_orders' not in eventpermset)
         ):
             self.fields.pop('pdf_data', None)
 

--- a/app/tests/tickets/api/test_checkin_offline_sync_acl.py
+++ b/app/tests/tickets/api/test_checkin_offline_sync_acl.py
@@ -1,0 +1,159 @@
+import datetime
+from decimal import Decimal
+
+import pytest
+from django_scopes import scopes_disabled
+from rest_framework.test import APIClient
+
+from eventyay.base.models import Device, Event, Order, OrderPosition, Organizer, Product, RevokedTicketSecret
+from eventyay.base.models.devices import generate_api_token
+
+
+@pytest.fixture
+def offline_sync_env():
+    with scopes_disabled():
+        organizer = Organizer.objects.create(name='Offline Org', slug='offline-org')
+        event = Event.objects.create(
+            organizer=organizer,
+            name='Offline Event',
+            slug='offline-event',
+            plugins='eventyay.plugins.badges',
+            date_from=datetime.datetime(2030, 1, 1, tzinfo=datetime.timezone.utc),
+            live=True,
+            tickets_published=True,
+        )
+        product = Product.objects.create(
+            event=event,
+            name='General',
+            default_price=0,
+            admission=True,
+        )
+        event.badge_layouts.create(name='Default', default=True)
+        order = Order.objects.create(
+            event=event,
+            email='attendee@example.test',
+            status=Order.STATUS_PAID,
+            datetime=datetime.datetime(2030, 1, 1, tzinfo=datetime.timezone.utc),
+            expires=datetime.datetime(2030, 2, 1, tzinfo=datetime.timezone.utc),
+            total=0,
+        )
+        position = OrderPosition.objects.create(
+            order=order,
+            product=product,
+            price=Decimal('0.00'),
+            attendee_name_parts={'full_name': 'Ada Lovelace', '_scheme': 'full'},
+            secret='secret-offline-sync',
+        )
+        RevokedTicketSecret.objects.create(event=event, position=None, secret='revoked-secret-1')
+        staff = Device.objects.create(
+            organizer=organizer,
+            all_events=True,
+            name='Check-In Staff',
+            initialized=datetime.datetime(2030, 1, 1, tzinfo=datetime.timezone.utc),
+            api_token=generate_api_token(),
+            security_profile='eventyay_checkin',
+        )
+        kiosk = Device.objects.create(
+            organizer=organizer,
+            all_events=True,
+            name='Badge Station',
+            initialized=datetime.datetime(2030, 1, 1, tzinfo=datetime.timezone.utc),
+            api_token=generate_api_token(),
+            security_profile='eventyay_checkin_online_kiosk',
+        )
+        yield {
+            'organizer': organizer,
+            'event': event,
+            'position': position,
+            'staff': staff,
+            'kiosk': kiosk,
+        }
+
+
+def _device_client(device):
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION='Device ' + device.api_token)
+    return client
+
+
+def _orders_url(env):
+    return '/api/v1/organizers/{}/events/{}/orders/'.format(env['organizer'].slug, env['event'].slug)
+
+
+def _revoked_url(env):
+    return '/api/v1/organizers/{}/events/{}/revokedsecrets/'.format(
+        env['organizer'].slug,
+        env['event'].slug,
+    )
+
+
+def _layouts_url(env):
+    return '/api/v1/organizers/{}/events/{}/badgelayouts/'.format(
+        env['organizer'].slug,
+        env['event'].slug,
+    )
+
+
+@pytest.mark.django_db
+def test_checkin_staff_can_list_orders_for_offline_sync(offline_sync_env):
+    env = offline_sync_env
+    client = _device_client(env['staff'])
+
+    resp = client.get(_orders_url(env) + '?ordering=last_modified')
+    assert resp.status_code == 200
+    assert 'X-Page-Generated' in resp
+    assert resp.data['count'] >= 1
+    codes = {row['code'] for row in resp.data['results']}
+    assert env['position'].order.code in codes
+    position = resp.data['results'][0]['positions'][0]
+    assert position['secret'] == 'secret-offline-sync'
+
+
+@pytest.mark.django_db
+def test_checkin_staff_can_list_revoked_secrets(offline_sync_env):
+    env = offline_sync_env
+    client = _device_client(env['staff'])
+
+    resp = client.get(_revoked_url(env))
+    assert resp.status_code == 200
+    secrets = {row['secret'] for row in resp.data['results']}
+    assert 'revoked-secret-1' in secrets
+
+
+@pytest.mark.django_db
+def test_checkin_staff_can_list_badge_layouts_for_offline_sync(offline_sync_env):
+    env = offline_sync_env
+    client = _device_client(env['staff'])
+
+    resp = client.get(_layouts_url(env))
+    assert resp.status_code == 200
+    names = {row['name'] for row in resp.data['results']}
+    assert 'Default' in names
+    assert 'layout' in resp.data['results'][0]
+
+
+@pytest.mark.django_db
+def test_badge_station_cannot_list_orders_for_sync(offline_sync_env):
+    env = offline_sync_env
+    client = _device_client(env['kiosk'])
+
+    resp = client.get(_orders_url(env))
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_badge_station_cannot_list_revoked_secrets(offline_sync_env):
+    env = offline_sync_env
+    client = _device_client(env['kiosk'])
+
+    resp = client.get(_revoked_url(env))
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_badge_station_cannot_list_badge_layouts(offline_sync_env):
+    env = offline_sync_env
+    client = _device_client(env['kiosk'])
+
+    resp = client.get(_layouts_url(env))
+    assert resp.status_code == 403

--- a/doc/api-reference/deviceauth.rst
+++ b/doc/api-reference/deviceauth.rst
@@ -145,8 +145,13 @@ Device authentication is currently hardcoded to grant the following permissions:
 Devices cannot change events or products and cannot access vouchers.
 
 Additionally, when creating a device through the user interface or API, a user can specify a "security profile" for
-the device. These include an allow list of specific API calls that may be made by the device. eventyay ships with security
-policies for official eventyay apps like pretixSCAN and pretixPOS.
+the device. These include an allow list of specific API calls that may be made by the device. eventyay ships with:
+
+* ``full`` — Full device access (lead scanning and unrestricted API use within device permissions).
+* ``eventyay_checkin`` — Check-In Staff: redeem, search, live registration, badge printing, and **offline sync**
+  (``GET`` event ``orders`` with ``modified_since`` / ``pdf_data``, ``revokedsecrets``, and badge layouts).
+* ``eventyay_checkin_online_kiosk`` — Badge Station (kiosk): online check-in and badge printing only (no order sync,
+  no revoked-secret sync, no live registration).
 
 Removing a device
 -----------------


### PR DESCRIPTION
## Summary
Unlocks offline sync for Check-In Staff device tokens used by eventyay-checkin:
- Allow `eventyay_checkin` devices to `GET` event `orders`, `revokedsecrets`, and badge layout/product list endpoints
- Keep Badge Station / kiosk (`eventyay_checkin_online_kiosk`) blocked from those sync endpoints (NoSync)
- Document the three device security profiles in `deviceauth.rst`
- Keep nested `pdf_data` available when `eventpermset` is not bound yet during serializer init

**Client PRs:** https://github.com/fossasia/eventyay-checkin/pull/139 → #142  
**Issue:** https://github.com/fossasia/eventyay-checkin/issues/103

## Motivation
Without these ACL grants, Check-In Staff cannot download the offline snapshot the client needs.

## Testing guide

### Automated
```bash
cd app
pytest tests/tickets/api/test_checkin_offline_sync_acl.py -q
```
Expected: 6 passed (staff allowed, kiosk denied).

### Manual setup
1. Run Eventyay with this branch (Docker or local).
2. Create/use an event with the badges plugin enabled and at least one paid order + check-in list.
3. Pair two devices (or reuse tokens):
   - **Check-In Staff** → security profile `eventyay_checkin`
   - **Badge Station** → security profile `eventyay_checkin_online_kiosk`

### Manual checks (API with device token)
Replace `ORG`, `EVENT`, and `TOKEN`.

**Check-In Staff — should succeed (200):**
```bash
curl -sS -H "Authorization: Device $TOKEN" \
  "https://YOUR_HOST/api/v1/organizers/ORG/events/EVENT/orders/?page_size=1" | head
curl -sS -H "Authorization: Device $TOKEN" \
  "https://YOUR_HOST/api/v1/organizers/ORG/events/EVENT/revokedsecrets/" | head
curl -sS -H "Authorization: Device $TOKEN" \
  "https://YOUR_HOST/api/v1/organizers/ORG/events/EVENT/badgelayouts/" | head
```

**Badge Station — should fail (403):**
```bash
curl -i -H "Authorization: Device $KIOSK_TOKEN" \
  "https://YOUR_HOST/api/v1/organizers/ORG/events/EVENT/orders/?page_size=1"
```

### Checklist
- [x] `pytest tests/tickets/api/test_checkin_offline_sync_acl.py` (6 passed)
- [ ] Check-In Staff can `GET` orders / revokedsecrets / badgelayouts
- [ ] Badge Station / kiosk gets 403 on those sync endpoints
- [ ] Existing online redeem/check-in still works for both profiles

## Risk and Rollback
- Risk: broader read access for Check-In Staff tokens (still device-scoped to assigned events)
- Rollback: revert this PR; client offline sync will fail closed on those endpoints

## Reviewer Notes
Focus on `devicesecurity.py` allowlists and the staff-vs-kiosk matrix in the new ACL tests. Independent of client PR merge order, but both are required for E2E offline sync.