### PR TITLE
Update Dependabot schedule to daily updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,20 +4,25 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "daily"
+      time: "06:00"
+      timezone: "Asia/Singapore"
+    open-pull-requests-limit: 15
 
   - package-ecosystem: "uv"
     directory: "/app"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "daily"
+      time: "06:00"
+      timezone: "Asia/Singapore"
+    open-pull-requests-limit: 15
     versioning-strategy: increase
     ignore:
       - dependency-name: "django"
         versions: [">=6.0.0"]
       - dependency-name: "stripe"
         versions: [">=11.4.0"]
+
       # Ignore all setuptools updates; issue is not version-specific.
       # Can be removed once Dependabot handles no-op uv updates.
       - dependency-name: "setuptools"
@@ -25,17 +30,23 @@ updates:
   - package-ecosystem: "npm"
     directory: "/app/eventyay/webapp/video"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "daily"
+      time: "06:00"
+      timezone: "Asia/Singapore"
+    open-pull-requests-limit: 15
 
   - package-ecosystem: "npm"
     directory: "/app/eventyay/webapp/schedule"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "daily"
+      time: "06:00"
+      timezone: "Asia/Singapore"
+    open-pull-requests-limit: 15
 
   - package-ecosystem: "npm"
     directory: "/app/eventyay/webapp/schedule-editor"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "daily"
+      time: "06:00"
+      timezone: "Asia/Singapore"
+    open-pull-requests-limit: 15

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,6 @@ updates:
         versions: [">=6.0.0"]
       - dependency-name: "stripe"
         versions: [">=11.4.0"]
-
       # Ignore all setuptools updates; issue is not version-specific.
       # Can be removed once Dependabot handles no-op uv updates.
       - dependency-name: "setuptools"


### PR DESCRIPTION
Changed the schedule for Dependabot updates to daily with a limit of 15 open pull requests for various package ecosystems.

## Summary by Sourcery

Build:
- Configure Dependabot for all defined ecosystems (GitHub Actions, uv, npm subprojects) to run daily at 06:00 Asia/Singapore time with a maximum of 15 open update PRs.