### PR TITLE
fix(events): restore event creation after #4770 locale regression

### DIFF
--- a/app/eventyay/control/forms/event.py
+++ b/app/eventyay/control/forms/event.py
@@ -178,6 +178,7 @@ class EventWizardBasicsForm(I18nModelForm):
     locale = forms.ChoiceField(
         choices=settings.LANGUAGES,
         label=_('Default language'),
+        required=False,
     )
     tax_rate = forms.DecimalField(
         label=_('Sales tax rate'),
@@ -286,6 +287,8 @@ class EventWizardBasicsForm(I18nModelForm):
 
     def clean(self):
         data = super().clean()
+        if not data.get('locale') and self.locales:
+            data['locale'] = self.locales[0]
         if data.get('locale') not in self.locales:
             if self.locales:
                 data['locale'] = self.locales[0]

--- a/app/eventyay/eventyay_common/templates/eventyay_common/events/create.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/events/create.html
@@ -104,7 +104,7 @@
             <fieldset>
                 <legend>{% trans "Localization" %}</legend>
                 {% bootstrap_field foundation_form.locales layout="control" %}
-                <input type="hidden" name="basics-locale" id="id_basics-locale" value="{{ basics_form.locale.value|default:foundation_form.locales.value.0|default:'en' }}">
+                <input type="hidden" name="basics-locale" id="id_basics-locale" value="{% firstof basics_form.locale.value foundation_form.locales.value|first 'en' %}">
             </fieldset>
 
             <fieldset>

--- a/app/eventyay/static/eventyay-common/js/ui/event-create.js
+++ b/app/eventyay/static/eventyay-common/js/ui/event-create.js
@@ -204,8 +204,11 @@
 
     function syncLocaleOrder() {
         var hiddenLocaleInput = document.getElementById("id_basics-locale");
+        updateLocaleOrderList();
         if (hiddenLocaleInput) {
-            hiddenLocaleInput.value = currentLocaleOrder[0] || "";
+            var checkedLocales = getCheckedLocalesFromDOM();
+            hiddenLocaleInput.value =
+                currentLocaleOrder[0] || hiddenLocaleInput.value || checkedLocales[0] || "en";
         }
         renderLanguageBadges();
     }
@@ -213,7 +216,8 @@
     function syncFoundationLocalesOnSubmit(form) {
         if (!form) return;
         updateLocaleOrderList();
-        if (currentLocaleOrder.length === 0) {
+        var localesToSubmit = currentLocaleOrder.length ? currentLocaleOrder : getCheckedLocalesFromDOM();
+        if (localesToSubmit.length === 0) {
             return;
         }
         var checkboxes = form.querySelectorAll('input[type="checkbox"][name="foundation-locales"]');
@@ -231,7 +235,7 @@
         var container = document.createElement("div");
         container.id = "event-create-locales-order-container";
         container.style.display = "none";
-        currentLocaleOrder.forEach(function (code) {
+        localesToSubmit.forEach(function (code) {
             var hidden = document.createElement("input");
             hidden.type = "hidden";
             hidden.name = "foundation-locales";
@@ -239,6 +243,10 @@
             container.appendChild(hidden);
         });
         form.appendChild(container);
+        var hiddenLocaleInput = document.getElementById("id_basics-locale");
+        if (hiddenLocaleInput && !hiddenLocaleInput.value) {
+            hiddenLocaleInput.value = localesToSubmit[0] || "en";
+        }
     }
 
     function updateDefaultLanguageChoices() {

--- a/app/eventyay/static/eventyay-common/js/ui/event-create.js
+++ b/app/eventyay/static/eventyay-common/js/ui/event-create.js
@@ -212,6 +212,10 @@
 
     function syncFoundationLocalesOnSubmit(form) {
         if (!form) return;
+        updateLocaleOrderList();
+        if (currentLocaleOrder.length === 0) {
+            return;
+        }
         var checkboxes = form.querySelectorAll('input[type="checkbox"][name="foundation-locales"]');
         checkboxes.forEach(function (input) {
             input.removeAttribute("name");

--- a/app/tests/tickets/control/test_events.py
+++ b/app/tests/tickets/control/test_events.py
@@ -773,6 +773,26 @@ class EventsTest(SoupTest):
             ev = Event.objects.get(slug='reordered-lang-event')
             assert ev.settings.locale == 'de'
 
+    def test_create_event_without_locales_returns_validation_error(self):
+        response = self.client.post(
+            '/common/events/add',
+            {
+                'foundation-organizer': self.orga1.pk,
+                'basics-locale': 'en',
+                'basics-name_0': 'No Locales',
+                'basics-slug': 'no-locales-test',
+                'basics-date_from_0': '2016-12-27',
+                'basics-date_from_1': '10:00:00',
+                'basics-date_to_0': '2016-12-30',
+                'basics-date_to_1': '19:00:00',
+                'basics-location_0': 'Berlin',
+                'basics-currency': 'EUR',
+                'basics-timezone': 'Europe/Berlin',
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('could not create', response.content.decode().lower())
+
     def test_create_duplicate_slug(self):
         doc = self.post_doc(
             '/control/events/add',

--- a/app/tests/tickets/control/test_events.py
+++ b/app/tests/tickets/control/test_events.py
@@ -793,6 +793,29 @@ class EventsTest(SoupTest):
         self.assertEqual(response.status_code, 200)
         self.assertIn('could not create', response.content.decode().lower())
 
+    def test_create_event_defaults_locale_from_selected_languages(self):
+        response = self.client.post(
+            '/common/events/add',
+            {
+                'foundation-organizer': self.orga1.pk,
+                'foundation-locales': 'en',
+                'basics-locale': '',
+                'basics-name_0': 'Default English',
+                'basics-slug': 'default-english-event',
+                'basics-date_from_0': '2016-12-27',
+                'basics-date_from_1': '10:00:00',
+                'basics-date_to_0': '2016-12-30',
+                'basics-date_to_1': '19:00:00',
+                'basics-location_0': 'Berlin',
+                'basics-currency': 'EUR',
+                'basics-timezone': 'Europe/Berlin',
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        with scopes_disabled():
+            ev = Event.objects.get(slug='default-english-event')
+            assert ev.settings.locale == 'en'
+
     def test_create_duplicate_slug(self):
         doc = self.post_doc(
             '/control/events/add',

--- a/app/tests/tickets/control/test_events.py
+++ b/app/tests/tickets/control/test_events.py
@@ -791,7 +791,8 @@ class EventsTest(SoupTest):
             },
         )
         self.assertEqual(response.status_code, 200)
-        self.assertIn('could not create', response.content.decode().lower())
+        foundation_form = response.context['foundation_form']
+        self.assertIn('locales', foundation_form.errors)
 
     def test_create_event_defaults_locale_from_selected_languages(self):
         response = self.client.post(


### PR DESCRIPTION
Fixes #4930

## Summary

Fixes event creation regressions introduced by #4770 (hidden default-locale field + JS locale reordering on submit).

### Bug 1: 500 on validation errors with no locales
- Submitting without `foundation-locales` crashed the error page template on `foundation_form.locales.value.0` because an empty list is truthy in Django templates, so `|default` never applied.
- **Fix:** use `{% firstof ... foundation_form.locales.value|first 'en' %}` in `create.html`.

### Bug 2: Default English / single-language create fails
- `syncLocaleOrder()` cleared the hidden `basics-locale` field **before** reading checked languages, so the default English selection posted an empty locale and validation failed.
- **Fix:** read checked languages first, preserve the server-rendered value as fallback, and default `basics-locale` server-side from `foundation-locales` when omitted.

### JS hardening
- Derive locale order before updating the hidden field.
- Fall back to checked checkboxes when `currentLocaleOrder` is empty instead of stripping checkbox names with nothing to submit.

## Files changed
- `app/eventyay/eventyay_common/templates/eventyay_common/events/create.html` — safe default-locale rendering
- `app/eventyay/static/eventyay-common/js/ui/event-create.js` — correct submit-time locale sync
- `app/eventyay/control/forms/event.py` — default `basics-locale` from selected foundation locales
- `app/tests/tickets/control/test_events.py` — regression tests

## Test plan
- [x] `POST /common/events/add` without `foundation-locales` returns **200** with `foundation_form.errors['locales']` (not 500)
- [x] `POST /common/events/add` with `foundation-locales=en` and empty `basics-locale` creates event with `locale=en`
- [x] Normal event creation with explicit locales still succeeds
- [ ] CI green