### PR TITLE
feat(api): download badge layout background PDFs for offline print

### DIFF
--- a/app/eventyay/api/auth/devicesecurity.py
+++ b/app/eventyay/api/auth/devicesecurity.py
@@ -86,8 +86,10 @@ _CHECKIN_CORE_ALLOWLIST = (
     # Badge layout picker for staff / kiosk print prompts
     ('GET', 'api-v1:badgelayout-list'),
     ('GET', 'api-v1:badgelayout-detail'),
+    ('GET', 'api-v1:badgelayout-background'),
     ('GET', 'api-v1:badgelayouts-list'),
     ('GET', 'api-v1:badgelayouts-detail'),
+    ('GET', 'api-v1:badgelayouts-background'),
     ('GET', 'api-v1:badgeproduct-list'),
     ('GET', 'api-v1:badgeproduct-detail'),
     ('GET', 'api-v1:badgeitems-list'),
@@ -108,8 +110,10 @@ _CHECKIN_STAFF_EXTRA_ALLOWLIST = (
     # Offline badge print: layout JSON synced separately from per-attendee pdf_data.
     ('GET', 'api-v1:badgelayout-list'),
     ('GET', 'api-v1:badgelayout-detail'),
+    ('GET', 'api-v1:badgelayout-background'),
     ('GET', 'api-v1:badgelayouts-list'),
     ('GET', 'api-v1:badgelayouts-detail'),
+    ('GET', 'api-v1:badgelayouts-background'),
     ('GET', 'api-v1:badgeproduct-list'),
     ('GET', 'api-v1:badgeproduct-detail'),
     ('GET', 'api-v1:badgeitems-list'),

--- a/app/eventyay/plugins/badges/api.py
+++ b/app/eventyay/plugins/badges/api.py
@@ -3,6 +3,7 @@ import base64
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from rest_framework import status, viewsets
+from rest_framework.decorators import action
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -13,6 +14,7 @@ from eventyay.base.models import OrderPosition
 from eventyay.base.services.tickets import generate_orderposition
 
 from .apps import PDFRenderer
+from .exporters import _open_layout_background
 from .models import BadgeLayout, BadgeProduct
 
 
@@ -58,6 +60,24 @@ class BadgeLayoutViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         return self.request.event.badge_layouts.all()
+
+    @action(detail=True, methods=['get'])
+    def background(self, request, **kwargs):
+        """Return the PDF the server uses as this layout's badge background."""
+        layout = self.get_object()
+        try:
+            background_file = _open_layout_background(layout)
+        except (OSError, TypeError, ValueError):
+            return Response({'detail': 'No badge background is available.'}, status=status.HTTP_404_NOT_FOUND)
+        try:
+            pdf_bytes = background_file.read()
+        finally:
+            background_file.close()
+        if not pdf_bytes:
+            return Response({'detail': 'No badge background is available.'}, status=status.HTTP_404_NOT_FOUND)
+        response = HttpResponse(pdf_bytes, content_type='application/pdf')
+        response['Content-Disposition'] = f'inline; filename="badge-background-{layout.pk}.pdf"'
+        return response
 
 
 class BadgeProductViewSet(viewsets.ReadOnlyModelViewSet):

--- a/app/tests/tickets/api/test_checkin_offline_sync_acl.py
+++ b/app/tests/tickets/api/test_checkin_offline_sync_acl.py
@@ -133,6 +133,16 @@ def test_checkin_staff_can_list_badge_layouts_for_offline_sync(offline_sync_env)
 
 
 @pytest.mark.django_db
+def test_checkin_staff_can_download_badge_layout_background(offline_sync_env):
+    env = offline_sync_env
+    client = _device_client(env['staff'])
+    layout = env['event'].badge_layouts.get(default=True)
+
+    resp = client.get(f'{_layouts_url(env)}{layout.pk}/background/')
+    assert resp.status_code in (200, 404)
+
+
+@pytest.mark.django_db
 def test_badge_station_cannot_list_orders_for_sync(offline_sync_env):
     env = offline_sync_env
     client = _device_client(env['kiosk'])

--- a/app/tests/tickets/plugins/badges/test_api.py
+++ b/app/tests/tickets/plugins/badges/test_api.py
@@ -85,3 +85,19 @@ def test_api_detail(env, client):
         ).content.decode('utf-8')
     )
     assert response == res
+
+
+@pytest.mark.django_db
+def test_api_background_download(env, client):
+    client.login(email='dummy@dummy.dummy', password='dummy')
+    response = client.get(
+        '/api/v1/organizers/{}/events/{}/badgelayouts/{}/background/'.format(
+            env[0].organizer.slug,
+            env[0].slug,
+            env[2].pk,
+        )
+    )
+    assert response.status_code in (200, 404)
+    if response.status_code == 200:
+        assert response['Content-Type'] == 'application/pdf'
+        assert response.content[:4] == b'%PDF'


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/organizers/{org}/events/{event}/badgelayouts/{id}/background/` returning the exact PDF the server uses as the badge background (custom file, bundled match, or default).
- Allow Check-In Staff / badge-layout device profiles to call this endpoint so eventyay-checkin can sync backgrounds for offline printing.

## Test plan
- [ ] `GET .../badgelayouts/{id}/background/` as an organizer user returns `application/pdf`
- [ ] Check-In Staff device token can call the same URL (200 or 404 if no default PDF is installed)
- [ ] Badge layout JSON list is unchanged

## Summary by Sourcery

Expose a per-badge-layout background PDF download endpoint and permit badge check-in device profiles to access it for offline printing.

New Features:
- Add a GET endpoint on BadgeLayout to download the PDF used as the layout background for an event.
- Allow check-in staff and badge-layout device profiles to request badge layout background PDFs via the new endpoint for offline sync.

Enhancements:
- Extend device security ACLs to whitelist the new badge layout background download routes for staff and offline badge printing flows.

Tests:
- Add API tests verifying badge layout background downloads return PDF data or 404 for organizers.
- Add ACL tests confirming check-in staff device clients can access the badge layout background download endpoint.