### PR TITLE
refactor: rename PretixWidget to EventyayWidget in JS widget API

### DIFF
--- a/app/eventyay/static/pretixpresale/js/widget/widget.js
+++ b/app/eventyay/static/pretixpresale/js/widget/widget.js
@@ -3,12 +3,14 @@
 /* This is embedded in an isolation wrapper that exposes siteglobals as the global
    scope. */
 
-window.PretixWidget = {
+window.EventyayWidget = {
     'build_widgets': true,
     'widget_data': {
         'referer': location.href
     }
 };
+// Backward compatibility alias for existing embeds on customer sites
+window.PretixWidget = window.EventyayWidget;
 
 var Vue = module.exports;
 Vue.component('resize-observer', VueResize.ResizeObserver)
@@ -1321,8 +1323,8 @@ var shared_root_methods = {
     },
     trigger_load_callback: function () {
         this.$nextTick(function () {
-            for (var i = 0; i < window.PretixWidget._loaded.length; i++) {
-                window.PretixWidget._loaded[i]()
+            for (var i = 0; i < window.EventyayWidget._loaded.length; i++) {
+                window.EventyayWidget._loaded[i]()
             }
         });
     },
@@ -1591,7 +1593,7 @@ var create_widget = function (element) {
     var skip_ssl = element.attributes["skip-ssl-check"] ? true : false;
     var disable_iframe = element.attributes["disable-iframe"] ? true : false;
     var disable_vouchers = element.attributes["disable-vouchers"] ? true : false;
-    var widget_data = JSON.parse(JSON.stringify(window.PretixWidget.widget_data));
+    var widget_data = JSON.parse(JSON.stringify(window.EventyayWidget.widget_data));
     var filter = element.attributes.filter ? element.attributes.filter.value : null;
     var items = element.attributes.items ? element.attributes.items.value : null;
     var categories = element.attributes.categories ? element.attributes.categories.value : null;
@@ -1671,7 +1673,7 @@ var create_button = function (element) {
     var skip_ssl = element.attributes["skip-ssl-check"] ? true : false;
     var disable_iframe = element.attributes["disable-iframe"] ? true : false;
     var button_text = element.innerHTML;
-    var widget_data = JSON.parse(JSON.stringify(window.PretixWidget.widget_data));
+    var widget_data = JSON.parse(JSON.stringify(window.EventyayWidget.widget_data));
     for (var i = 0; i < element.attributes.length; i++) {
         var attrib = element.attributes[i];
         if (attrib.name.match(/^data-.*$/)) {
@@ -1723,11 +1725,11 @@ var create_button = function (element) {
 /* Find all widgets on the page and render them */
 widgetlist = [];
 buttonlist = [];
-window.PretixWidget._loaded = [];
-window.PretixWidget.addLoadListener = function (f) {
-    window.PretixWidget._loaded.push(f);
+window.EventyayWidget._loaded = [];
+window.EventyayWidget.addLoadListener = function (f) {
+    window.EventyayWidget._loaded.push(f);
 }
-window.PretixWidget.buildWidgets = function () {
+window.EventyayWidget.buildWidgets = function () {
     document.createElement("pretix-widget");
     document.createElement("pretix-button");
     docReady(function () {
@@ -1747,12 +1749,12 @@ window.PretixWidget.buildWidgets = function () {
     });
 };
 
-window.PretixWidget.open = function (target_url, voucher, subevent, items, widget_data, skip_ssl_check, disable_iframe) {
+window.EventyayWidget.open = function (target_url, voucher, subevent, items, widget_data, skip_ssl_check, disable_iframe) {
     if (!target_url.match(/\/$/)) {
         target_url += "/";
     }
 
-    var all_widget_data = JSON.parse(JSON.stringify(window.PretixWidget.widget_data));
+    var all_widget_data = JSON.parse(JSON.stringify(window.EventyayWidget.widget_data));
     if (widget_data) {
         Object.keys(widget_data).forEach(function(key) { all_widget_data[key] = widget_data[key]; });
     }
@@ -1795,11 +1797,14 @@ window.PretixWidget.open = function (target_url, voucher, subevent, items, widge
     })
 };
 
+if (typeof window.eventyayWidgetCallback !== "undefined") {
+    window.eventyayWidgetCallback();
+}
 if (typeof window.pretixWidgetCallback !== "undefined") {
     window.pretixWidgetCallback();
 }
-if (window.PretixWidget.build_widgets) {
-    window.PretixWidget.buildWidgets();
+if (window.EventyayWidget.build_widgets) {
+    window.EventyayWidget.buildWidgets();
 }
 
 /* Set a global variable for debugging. In DEBUG mode, siteglobals will be window, otherwise it will be something

--- a/doc/user/events/widget.rst
+++ b/doc/user/events/widget.rst
@@ -222,7 +222,7 @@ missing HTTPS encryption on your case or a really small screen (mobile), it will
 Therefore, make sure you call this *in direct response to a user action*, otherwise most browser will block it as an
 unwanted pop-up.
 
-.. js:function:: window.PretixWidget.open(target_url [, voucher [, subevent [, items, [, widget_data [, skip_ssl_check ]]]]])
+.. js:function:: window.EventyayWidget.open(target_url [, voucher [, subevent [, items, [, widget_data [, skip_ssl_check ]]]]])
 
    :param string target_url: The URL of the ticket shop.
    :param string voucher: A voucher code to be pre-selected, or ``null``.
@@ -238,7 +238,7 @@ If you need to control the way or timing the widget loads, for example because y
 below) dynamically via JavaScript, you can register a listener that we will call before creating the widget::
 
     <script type="text/javascript">
-    window.pretixWidgetCallback = function () {
+    window.eventyayWidgetCallback = function () {
         // Will be run before we create the widget.
     }
     </script>
@@ -246,13 +246,13 @@ below) dynamically via JavaScript, you can register a listener that we will call
 If you want, you can suppress us loading the widget and/or modify the user data passed to the widget::
 
     <script type="text/javascript">
-    window.pretixWidgetCallback = function () {
-        window.PretixWidget.build_widgets = false;
-        window.PretixWidget.widget_data["email"] = "test@example.org";
+    window.eventyayWidgetCallback = function () {
+        window.EventyayWidget.build_widgets = false;
+        window.EventyayWidget.widget_data["email"] = "test@example.org";
     }
     </script>
 
-If you then later want to trigger loading the widgets, just call ``window.PretixWidget.buildWidgets()``.
+If you then later want to trigger loading the widgets, just call ``window.EventyayWidget.buildWidgets()``.
 
 Waiting for the widget to load
 ------------------------------
@@ -262,8 +262,8 @@ this function might be run multiple times, for example if you have multiple widg
 e.g. from an event list to an event detail view::
 
     <script type="text/javascript">
-    window.pretixWidgetCallback = function () {
-        window.PretixWidget.addLoadListener(function () {
+    window.eventyayWidgetCallback = function () {
+        window.EventyayWidget.addLoadListener(function () {
             console.log("Widget has loaded!");
         });
     }
@@ -332,11 +332,11 @@ Hosted or eventyay Enterprise are active, you can pass the following fields:
         gtag('js', new Date());
         gtag('config', '<MEASUREMENT_ID>');
 
-        window.pretixWidgetCallback = function () {
-            window.PretixWidget.build_widgets = false;
+        window.eventyayWidgetCallback = function () {
+            window.EventyayWidget.build_widgets = false;
             window.addEventListener('load', function() { // Wait for GA to be loaded
                 if (!window['google_tag_manager']) {
-                    window.PretixWidget.buildWidgets();
+                    window.EventyayWidget.buildWidgets();
                     return;
                 }
 
@@ -348,9 +348,9 @@ Hosted or eventyay Enterprise are active, you can pass the following fields:
                     if (!loadingTimeout) return;
                     window.clearTimeout(loadingTimeout);
                     loadingTimeout = null;
-                    if (clientId) window.PretixWidget.widget_data["tracking-ga-id"] = clientId;
-                    if (sessionId) window.PretixWidget.widget_data["tracking-ga-sessid"] = sessionId;
-                    window.PretixWidget.buildWidgets();
+                    if (clientId) window.EventyayWidget.widget_data["tracking-ga-id"] = clientId;
+                    if (sessionId) window.EventyayWidget.widget_data["tracking-ga-sessid"] = sessionId;
+                    window.EventyayWidget.buildWidgets();
                 };
                 // make sure to build eventyay-widgets if gtag fails to load either client_id or session_id
                 loadingTimeout = window.setTimeout(build, 2000);
@@ -376,25 +376,25 @@ Hosted or eventyay Enterprise are active, you can pass the following fields:
         gtag('js', new Date());
         gtag('config', '<MEASUREMENT_ID>');
 
-        window.pretixWidgetCallback = function () {
-            window.PretixWidget.build_widgets = false;
+        window.eventyayWidgetCallback = function () {
+            window.EventyayWidget.build_widgets = false;
             window.addEventListener('load', function() { // Wait for GA to be loaded
                 if (!window['google_tag_manager']) {
-                    window.PretixWidget.buildWidgets();
+                    window.EventyayWidget.buildWidgets();
                     return;
                 }
 
                 // make sure to build eventyay-widgets if gtag fails to load client_id
                 var loadingTimeout = window.setTimeout(function() {
                     loadingTimeout = null;
-                    window.PretixWidget.buildWidgets();
+                    window.EventyayWidget.buildWidgets();
                 }, 1000);
 
                 gtag('get', '<MEASUREMENT_ID>', 'client_id', function(id) {
                     if (loadingTimeout) {
                         window.clearTimeout(loadingTimeout);
-                        window.PretixWidget.widget_data["tracking-ga-id"] = id;
-                        window.PretixWidget.buildWidgets();
+                        window.EventyayWidget.widget_data["tracking-ga-id"] = id;
+                        window.EventyayWidget.buildWidgets();
                     }
                 });
             });
@@ -412,24 +412,24 @@ Hosted or eventyay Enterprise are active, you can pass the following fields:
         ga('create', '<MEASUREMENT_ID>', 'auto');
         ga('send', 'pageview');
 
-        window.pretixWidgetCallback = function () {
-            window.PretixWidget.build_widgets = false;
+        window.eventyayWidgetCallback = function () {
+            window.EventyayWidget.build_widgets = false;
             window.addEventListener('load', function() { // Wait for GA to be loaded
                 if (!window['ga'] || !ga.create) {
                     // Tracking is probably blocked
-                    window.PretixWidget.buildWidgets()
+                    window.EventyayWidget.buildWidgets()
                     return;
                 }
 
                 var loadingTimeout = window.setTimeout(function() {
                     loadingTimeout = null;
-                    window.PretixWidget.buildWidgets();
+                    window.EventyayWidget.buildWidgets();
                 }, 1000);
                 ga(function(tracker) {
                     if (loadingTimeout) {
                         window.clearTimeout(loadingTimeout);
-                        window.PretixWidget.widget_data["tracking-ga-id"] = tracker.get('clientId');
-                        window.PretixWidget.buildWidgets();
+                        window.EventyayWidget.widget_data["tracking-ga-id"] = tracker.get('clientId');
+                        window.EventyayWidget.buildWidgets();
                     }
                 });
             });


### PR DESCRIPTION
Fixes #4935

## Summary
Renames the embeddable ticket widget's global JavaScript identifier from `window.PretixWidget` to `window.EventyayWidget`, and the callback hook from `window.pretixWidgetCallback` to `window.eventyayWidgetCallback`, completing the rebrand from pretix to eventyay in the public-facing widget API.

## Backward compatibility
Since this widget script is embedded on third-party customer websites, breaking the old API would break live embeds. To avoid this:
- `window.PretixWidget` is kept as an alias pointing to the same object as `window.EventyayWidget` (not a copy — a direct reference, so all methods stay in sync).
- `window.pretixWidgetCallback`, if defined by a customer's embed, is still detected and invoked alongside the new `window.eventyayWidgetCallback`.

Existing embeds using the old names will continue to work unchanged. New embeds and the documentation now use `EventyayWidget` / `eventyayWidgetCallback`.

## Out of scope
The custom HTML elements `<pretix-widget>` and `<pretix-button>` were intentionally left unchanged — the issue specifically scoped this to the JS global identifier, and renaming the HTML tags would be a separate, larger breaking change requiring its own compatibility strategy.

## Changes
- `app/eventyay/static/pretixpresale/js/widget/widget.js`
- `doc/user/events/widget.rst`

## Summary by Sourcery

Rename the public JavaScript ticket widget API from PretixWidget to EventyayWidget while preserving backward compatibility for existing embeds.

New Features:
- Introduce window.EventyayWidget as the primary global JavaScript interface for the embeddable ticket widget.
- Add support for a new window.eventyayWidgetCallback hook that is invoked when the widget loads.

Enhancements:
- Maintain window.PretixWidget as a backward-compatible alias pointing to the EventyayWidget instance.
- Ensure both legacy window.pretixWidgetCallback and new window.eventyayWidgetCallback are executed when defined.
- Update internal widget code to use EventyayWidget as the canonical data and lifecycle container.

Documentation:
- Refresh widget documentation to reference EventyayWidget and eventyayWidgetCallback as the recommended public API.