### PR TITLE
Fix emoji picker overlay stacking

### DIFF
--- a/app/eventyay/webapp/video/src/components/EmojiPicker.vue
+++ b/app/eventyay/webapp/video/src/components/EmojiPicker.vue
@@ -28,10 +28,12 @@ export default {
 </script>
 <style lang="stylus">
 .c-emoji-picker
+	position: fixed
+	z-index: 9999
 	em-emoji-picker
 		--border-radius: 8px
 		--font-family: inherit
-		--rgb-background: var(--clr-background, #fff)
-		--rgb-color: var(--clr-primary-text, #333)
-		--rgb-input: var(--clr-grey-200, #eee)
+		--rgb-background: 255, 255, 255
+		--rgb-color: 51, 51, 51
+		--rgb-input: 238, 238, 238
 </style>

--- a/app/eventyay/webapp/video/src/components/EmojiPicker.vue
+++ b/app/eventyay/webapp/video/src/components/EmojiPicker.vue
@@ -29,7 +29,7 @@ export default {
 <style lang="stylus">
 .c-emoji-picker
 	position: fixed
-	z-index: 9999
+	z-index: 901
 	em-emoji-picker
 		--border-radius: 8px
 		--font-family: inherit

--- a/app/eventyay/webapp/video/src/components/EmojiPickerButton.vue
+++ b/app/eventyay/webapp/video/src/components/EmojiPickerButton.vue
@@ -8,8 +8,9 @@
 			path(d="m8 11.62a2 2 0 1 0-1e-3 3.999 2 2 0 0 0 1e-3 -3.999m8 0a2 2 0 1 0-1e-3 3.999 2 2 0 0 0 1e-3 -3.999m-0.768 8c-0.693 1.195-1.87 2-3.349 2-1.477 0-2.655-0.805-3.347-2h6.464m3-2h-12a6 6 0 1 0 12 0")
 			path(d="m23.047 0a1 1 0 0 0-1 1v3.6484h-3.6484a1 1 0 0 0-1 1 1 1 0 0 0 1 1h3.6484v3.6484a1 1 0 0 0 1 1 1 1 0 0 0 1-1v-3.6484h3.6484a1 1 0 0 0 1-1 1 1 0 0 0-1-1h-3.6484v-3.6484a1 1 0 0 0-1-1z")
 			path(d="m13.242 4.6836c-5.0865-0.52948-9.9583 2.2302-12.119 6.8652-2.1608 4.635-1.1425 10.142 2.5332 13.697 3.6757 3.5555 9.2129 4.3899 13.773 2.0762 4.5606-2.3138 7.1553-7.2758 6.457-12.342a1 1 0 0 0-1.127-0.85352 1 1 0 0 0-0.85352 1.127c0.58284 4.2284-1.5744 8.352-5.3809 10.283-3.8065 1.9312-8.4106 1.2391-11.479-1.7285-3.068-2.9676-3.9129-7.5455-2.1094-11.414 1.8036-3.8686 5.8522-6.1626 10.098-5.7207a1 1 0 0 0 1.0977-0.89062 1 1 0 0 0-0.89062-1.0996z")
-	.emoji-picker-blocker(v-if="showEmojiPicker", @click="showEmojiPicker = false, clearDismissTimer()")
-	emoji-picker(v-if="showEmojiPicker", ref="picker", @selected="selected", @mouseenter="resetDismissTimer", @mousemove="resetDismissTimer", @click="resetDismissTimer")
+	teleport(to="body")
+		.emoji-picker-blocker(v-if="showEmojiPicker", @click="showEmojiPicker = false, clearDismissTimer()")
+		emoji-picker(v-if="showEmojiPicker", ref="picker", @selected="selected", @mouseenter="resetDismissTimer", @mousemove="resetDismissTimer", @click="resetDismissTimer")
 </template>
 <script>
 import { createPopper } from '@popperjs/core'
@@ -28,7 +29,7 @@ export default {
 		},
 		strategy: {
 			type: String,
-			default: 'absolute'
+			default: 'fixed'
 		},
 		offset: {
 			type: Array,
@@ -116,13 +117,11 @@ export default {
 		svg
 			path
 				fill: $clr-primary-text-light
-	.emoji-picker-blocker
-		position: fixed
-		top: 0
-		left: 0
-		width: 100vw
-		height: var(--vh100)
-		z-index: 800
-	.c-emoji-picker
-		z-index: 801
+.emoji-picker-blocker
+	position: fixed
+	top: 0
+	left: 0
+	width: 100vw
+	height: var(--vh100)
+	z-index: 9998
 </style>

--- a/app/eventyay/webapp/video/src/components/EmojiPickerButton.vue
+++ b/app/eventyay/webapp/video/src/components/EmojiPickerButton.vue
@@ -123,5 +123,5 @@ export default {
 	left: 0
 	width: 100vw
 	height: var(--vh100)
-	z-index: 9998
+	z-index: 900
 </style>


### PR DESCRIPTION
Fixes #4922


https://github.com/user-attachments/assets/300eb7d8-4476-4abf-a1a9-8c2b3193843c

## Summary by Sourcery

Ensure the emoji picker overlay renders as a top-level, fixed-position element to avoid stacking and positioning issues over the video UI.

Bug Fixes:
- Prevent the emoji picker overlay from being obscured or mispositioned by other stacked elements in the video interface.

Enhancements:
- Teleport the emoji picker and its blocker to the document body and switch popper strategy to fixed for more reliable overlay positioning.
- Simplify and standardize z-index handling for the emoji picker overlay and blocker.
- Clean up redundant emoji picker theme variables from the component stylesheet.