### PR TITLE
Remove obsolete FIXME comments

### DIFF
--- a/app/eventyay/base/models/event.py
+++ b/app/eventyay/base/models/event.py
@@ -1010,7 +1010,7 @@ class Event(
         this event, so you don't have to prefix your cache keys. In addition, the cache
         is being cleared every time the event or one of its related objects change.
         """
-        # FIXME: This "cache" module is missing.
+        
         from eventyay.base.cache import ObjectRelatedCache
 
         return ObjectRelatedCache(self)

--- a/app/eventyay/base/models/organizer.py
+++ b/app/eventyay/base/models/organizer.py
@@ -215,7 +215,7 @@ class Organizer(LoggedModel, TimestampedModel, RulesModelMixin, models.Model, me
         this organizer, so you don't have to prefix your cache keys. In addition, the cache
         is being cleared every time the organizer changes.
         """
-        # FIXME: This "cache" module is missing.
+
         from eventyay.base.cache import ObjectRelatedCache
 
         return ObjectRelatedCache(self)


### PR DESCRIPTION
## What does this PR do?

Removes obsolete FIXME comments related to the cache module in:
- `app/eventyay/base/models/event.py`
- `app/eventyay/base/models/organizer.py`

## Why?

These FIXME comments are no longer needed and were requested to be removed as part of the issue.

## Changes
- Removed the obsolete FIXME comment from `event.py`
- Removed the obsolete FIXME comment from `organizer.py`

## Summary by Sourcery

Enhancements:
- Clean up outdated FIXME comments in event and organizer models related to the cache module.