### PR TITLE
chore:social-plugin-bump

### DIFF
--- a/app/uv.lock
+++ b/app/uv.lock
@@ -1207,7 +1207,7 @@ source = { git = "https://github.com/fossasia/eventyay-paypal.git?rev=main#a6d9c
 [[package]]
 name = "eventyay-socialmedia"
 version = "1.0.0"
-source = { git = "https://github.com/fossasia/eventyay-socialmedia.git?rev=dev#a352605b6c118b9e32d1acaad884f0cc9bae431d" }
+source = { git = "https://github.com/fossasia/eventyay-socialmedia.git?rev=dev#ee1058674ea7abf9c150e271916c2de51e3bff3e" }
 dependencies = [
     { name = "mastodon-py" },
 ]


### PR DESCRIPTION
updated uv.lock with social plugin latest commit hash.

## Summary by Sourcery

Update dependency lockfile to point to the latest social plugin commit hash.

Build:
- Refresh uv.lock to capture the latest social plugin revision.

Chores:
- Bump social plugin reference in the uv.lock file.