### PR TITLE
feat(poster): add direct file upload support to Poster model

### DIFF
--- a/app/eventyay/base/migrations/0055_poster_file_upload.py
+++ b/app/eventyay/base/migrations/0055_poster_file_upload.py
@@ -1,0 +1,44 @@
+import eventyay.base.models.poster
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0054_team_teamshifts_permissions'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='poster',
+            name='poster_file',
+            field=models.FileField(
+                blank=True,
+                max_length=255,
+                null=True,
+                upload_to=eventyay.base.models.poster.poster_file_path,
+                verbose_name='Poster File',
+            ),
+        ),
+        migrations.AddField(
+            model_name='poster',
+            name='poster_preview_file',
+            field=models.FileField(
+                blank=True,
+                max_length=255,
+                null=True,
+                upload_to=eventyay.base.models.poster.poster_preview_file_path,
+                verbose_name='Poster Preview File',
+            ),
+        ),
+        migrations.AlterField(
+            model_name='poster',
+            name='poster_url',
+            field=models.URLField(blank=True, max_length=2048, null=True, verbose_name='Poster URL'),
+        ),
+        migrations.AlterField(
+            model_name='poster',
+            name='poster_preview',
+            field=models.URLField(blank=True, max_length=2048, null=True, verbose_name='Poster Preview URL'),
+        ),
+    ]

--- a/app/eventyay/base/models/poster.py
+++ b/app/eventyay/base/models/poster.py
@@ -1,10 +1,27 @@
+from contextlib import suppress
 import uuid
 
 from django.db import models
+from django.utils.functional import cached_property
+from django.utils.translation import gettext_lazy as _
+
+from eventyay.common.text.path import path_with_hash
 
 
 def default_text():
     return []
+
+
+def poster_file_path(instance, filename: str) -> str:
+    event_slug = getattr(instance.event, "slug", str(instance.event_id))
+    base_path = f"events/{event_slug}/posters"
+    return path_with_hash(filename, base_path=base_path)
+
+
+def poster_preview_file_path(instance, filename: str) -> str:
+    event_slug = getattr(instance.event, "slug", str(instance.event_id))
+    base_path = f"events/{event_slug}/posters/previews"
+    return path_with_hash(filename, base_path=base_path)
 
 
 class Poster(models.Model):
@@ -16,8 +33,22 @@ class Poster(models.Model):
     tags = models.JSONField(default=default_text)
     category = models.TextField(null=True, blank=True)
 
-    poster_url = models.URLField(null=True, blank=True)  # TODO file upload
-    poster_preview = models.URLField(null=True, blank=True)  # TODO file upload
+    poster_url = models.URLField(null=True, blank=True, max_length=2048, verbose_name=_("Poster URL"))
+    poster_preview = models.URLField(null=True, blank=True, max_length=2048, verbose_name=_("Poster Preview URL"))
+    poster_file = models.FileField(
+        upload_to=poster_file_path,
+        null=True,
+        blank=True,
+        max_length=255,
+        verbose_name=_("Poster File"),
+    )
+    poster_preview_file = models.FileField(
+        upload_to=poster_preview_file_path,
+        null=True,
+        blank=True,
+        max_length=255,
+        verbose_name=_("Poster Preview File"),
+    )
     schedule_session = models.TextField(null=True, blank=True)
 
     event = models.ForeignKey(
@@ -44,6 +75,20 @@ class Poster(models.Model):
         blank=True,
         null=True,
     )
+
+    @cached_property
+    def resolved_poster_url(self):
+        if self.poster_file:
+            with suppress(ValueError):
+                return self.poster_file.url
+        return self.poster_url
+
+    @cached_property
+    def resolved_poster_preview(self):
+        if self.poster_preview_file:
+            with suppress(ValueError):
+                return self.poster_preview_file.url
+        return self.poster_preview
 
     def serialize(self, user=None, list_format=False):
         abstract = self.abstract
@@ -74,8 +119,8 @@ class Poster(models.Model):
             authors=self.authors,
             category=self.category,
             tags=self.tags,
-            poster_url=self.poster_url,
-            poster_preview=self.poster_preview,
+            poster_url=self.resolved_poster_url,
+            poster_preview=self.resolved_poster_preview,
         )
 
         if not list_format:
@@ -116,6 +161,12 @@ class Poster(models.Model):
         return r
 
     def delete(self, *args, **kwargs):
+        if self.poster_file:
+            with suppress(ValueError, OSError):
+                self.poster_file.delete(save=False)
+        if self.poster_preview_file:
+            with suppress(ValueError, OSError):
+                self.poster_preview_file.delete(save=False)
         r = super().delete(*args, **kwargs)
         self.parent_room.touch()
         return r

--- a/app/eventyay/base/services/poster.py
+++ b/app/eventyay/base/services/poster.py
@@ -161,6 +161,8 @@ class PosterService:
             "category",
             "poster_url",
             "poster_preview",
+            "poster_file",
+            "poster_preview_file",
             "schedule_session",
         )
         for key, value in data.items():

--- a/app/tests/base/test_poster_file_upload.py
+++ b/app/tests/base/test_poster_file_upload.py
@@ -1,0 +1,95 @@
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django_scopes import scopes_disabled
+import pytest
+
+from eventyay.base.models import Event, Organizer, Poster, Room
+from eventyay.base.models.poster import (
+    poster_file_path,
+    poster_preview_file_path,
+)
+
+
+@pytest.fixture
+def poster_setup():
+    with scopes_disabled():
+        org = Organizer.objects.create(name="Poster Org", slug="posterorg")
+        event = Event.objects.create(
+            organizer=org,
+            name="Poster Event",
+            slug="posterevent",
+            currency="EUR",
+        )
+        room = Room.objects.create(
+            event=event,
+            name="Poster Hall",
+        )
+    return event, room
+
+
+@pytest.mark.django_db
+def test_poster_paths(poster_setup):
+    event, room = poster_setup
+    with scopes_disabled():
+        poster = Poster.objects.create(
+            event=event,
+            parent_room=room,
+            title="Sample Research Poster",
+        )
+
+        file_path = poster_file_path(poster, "test_poster.pdf")
+        assert f"events/{event.slug}/posters/" in file_path
+        assert file_path.endswith(".pdf")
+
+        preview_path = poster_preview_file_path(poster, "test_preview.png")
+        assert f"events/{event.slug}/posters/previews/" in preview_path
+        assert preview_path.endswith(".png")
+
+
+@pytest.mark.django_db
+def test_poster_fallback_url_when_no_file(poster_setup):
+    event, room = poster_setup
+    with scopes_disabled():
+        poster = Poster.objects.create(
+            event=event,
+            parent_room=room,
+            title="External URL Poster",
+            poster_url="https://example.com/poster.pdf",
+            poster_preview="https://example.com/preview.png",
+        )
+
+        assert poster.resolved_poster_url == "https://example.com/poster.pdf"
+        assert poster.resolved_poster_preview == "https://example.com/preview.png"
+
+        serialized = poster.serialize()
+        assert serialized["poster_url"] == "https://example.com/poster.pdf"
+        assert serialized["poster_preview"] == "https://example.com/preview.png"
+
+
+@pytest.mark.django_db
+def test_poster_file_upload_resolution_and_serialization(poster_setup):
+    event, room = poster_setup
+    with scopes_disabled():
+        fake_pdf = SimpleUploadedFile("research.pdf", b"%PDF-1.4 test poster content", content_type="application/pdf")
+        fake_preview = SimpleUploadedFile("preview.png", b"\x89PNG\r\n\x1a\n test png", content_type="image/png")
+
+        poster = Poster.objects.create(
+            event=event,
+            parent_room=room,
+            title="Uploaded Research Poster",
+            poster_file=fake_pdf,
+            poster_preview_file=fake_preview,
+        )
+
+        assert poster.poster_file.name is not None
+        assert poster.poster_preview_file.name is not None
+        assert poster.resolved_poster_url == poster.poster_file.url
+        assert poster.resolved_poster_preview == poster.poster_preview_file.url
+
+        serialized = poster.serialize()
+        assert serialized["poster_url"] == poster.poster_file.url
+        assert serialized["poster_preview"] == poster.poster_preview_file.url
+
+        # Clean up files on deletion
+        poster_file_name = poster.poster_file.name
+        poster.delete()
+        assert not poster.poster_file.storage.exists(poster_file_name)


### PR DESCRIPTION
## Summary
Adds native direct file upload support for the `Poster` model (`poster_file` and `poster_preview_file`) with backward-compatible URL fallbacks and automated storage cleanup.

## Changes
- Add `poster_file_path` and `poster_preview_file_path` storage path generators.
- Add `poster_file` and `poster_preview_file` `FileField` fields to `Poster`.
- Add cached properties `resolved_poster_url` and `resolved_poster_preview` to resolve file URLs before falling back to external URLs.
- Update `serialize()` to return resolved URLs to frontend clients.
- Add file deletion cleanup on `Poster.delete()`.
- Add Django migration `0055_poster_file_upload.py`.
- Add unit tests in `app/tests/base/test_poster_file_upload.py`.

## Checklist
- [x] Target branch is `dev`
- [x] Follows Conventional Commits style
- [x] Multi-tenancy and scoping respected

## Summary by Sourcery

Add native file-based storage support to posters while preserving existing URL-based behaviour and ensuring storage cleanup on deletion.

New Features:
- Support uploading poster files and preview files directly on the Poster model with event-scoped storage paths.
- Expose resolved poster and preview URLs to clients, preferring stored files while falling back to external URLs.
- Allow PATCH updates to manage both URL and file-based poster fields.

Enhancements:
- Improve poster URL fields with explicit length limits and translated verbose names for better validation and admin display.

Tests:
- Add tests covering poster file path generation, URL fallback behaviour, file URL resolution in serialization, and cleanup of stored files on deletion.