### PR TITLE
Add CSV export for attendee feedback

### DIFF
--- a/app/eventyay/orga/templates/orga/submission/feedbacks_list.html
+++ b/app/eventyay/orga/templates/orga/submission/feedbacks_list.html
@@ -10,6 +10,15 @@
 {% block content %}
     {% trans "Attendee feedback" as header_title %}
     {% include "common/includes/header_nav.html" with header_title=header_title %}
+    <div class="submit-group panel mb-4">
+    <span></span>
+    <span>
+        <a href="?export=csv" class="btn btn-success">
+            <i class="fa fa-download"></i>
+            {% translate "Download CSV" %}
+        </a>
+    </span>
+    </div>
 
     {% regroup feedback|dictsort:"talk.title" by talk.title as feedbacks_list %}
 

--- a/app/eventyay/orga/views/submission.py
+++ b/app/eventyay/orga/views/submission.py
@@ -1,7 +1,10 @@
 import json
 from collections import Counter
 from operator import itemgetter
+import csv
+from io import StringIO
 
+from django.http import HttpResponse
 from dateutil import rrule
 from django.conf import settings
 from django.contrib import messages
@@ -1220,8 +1223,45 @@ class AllFeedbacksList(EventPermissionRequired, PaginationMixin, ListView):
     paginate_by = 25
 
     def get_queryset(self):
-        return Feedback.objects.order_by('-pk').select_related('talk').filter(talk__event=self.request.event)
+        return Feedback.objects.order_by('-pk').select_related(
+            'talk',
+            'speaker',
+        ).filter(
+            talk__event=self.request.event
+        )
 
+    def get(self, request, *args, **kwargs):
+        if request.GET.get('export') == 'csv':
+            return self.export_csv()
+        return super().get(request, *args, **kwargs)
+
+    def export_csv(self):
+        output = StringIO()
+        writer = csv.writer(output)
+
+        writer.writerow([
+            'Session',
+            'Speaker',
+            'Rating',
+            'Feedback',
+        ])
+
+        for feedback in self.get_queryset():
+            writer.writerow([
+                feedback.talk.title,
+                feedback.speaker.fullname if feedback.speaker else '',
+                feedback.rating,
+                feedback.review,
+            ])
+
+        response = HttpResponse(
+            output.getvalue(),
+            content_type='text/csv; charset=utf-8',
+        )
+        response['Content-Disposition'] = (
+            f'attachment; filename="{self.request.event.slug}_feedback.csv"'
+        )
+        return response
 
 class TagView(OrgaCRUDView):
     model = Tag


### PR DESCRIPTION
## Description

Adds CSV export functionality for submitted session feedback in **Organizer Dashboard → Submissions → Feedback**.

### Changes

**`app/eventyay/orga/views/submission.py`**

* Added `export=csv` handling in `AllFeedbacksList.get()`.
* Added `export_csv()` to generate and download feedback as CSV.
* Export columns: `Session`, `Speaker`, `Rating`, `Feedback`.

**`app/eventyay/orga/templates/orga/submission/feedbacks_list.html`**

* Added **Download CSV** button to trigger the export.

### Testing

* Verified CSV download from the Organizer Dashboard.
* Verified exported data contains session, speaker, rating, and feedback text.

Closes #4905
<img width="1911" height="249" alt="Screenshot 2026-08-18 021613" src="https://github.com/user-attachments/assets/c5b4a13c-69cd-4f29-b84d-5a3547b80c42" />
<img width="1915" height="955" alt="Screenshot 2026-08-18 021628" src="https://github.com/user-attachments/assets/5b67c6e7-3807-42c4-af13-8022410eede6" />

## Summary by Sourcery

New Features:
- Add a CSV download option for attendee feedback in the organizer dashboard, including session, speaker, rating, and feedback details.