### PR TITLE
fix: renumber global plugin config migration to 0056

### DIFF
--- a/app/eventyay/base/migrations/0056_global_plugin_config.py
+++ b/app/eventyay/base/migrations/0056_global_plugin_config.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('base', '0053_jitsiserver'),
+        ('base', '0055_alter_product_default_price_and_more'),
     ]
 
     operations = [


### PR DESCRIPTION
Renumbers `0054_global_plugin_config.py` to `0056_global_plugin_config.py` and updates its dependency from `0053_jitsiserver` to `0055_alter_product_default_price_and_more`

## Summary by Sourcery

Bug Fixes:
- Correct the global plugin configuration migration numbering and dependency ordering.