### PR TITLE
fix(migrations): resolve conflict for 0054_global_plugin_config

### DIFF
--- a/app/eventyay/base/migrations/0056_global_plugin_config.py
+++ b/app/eventyay/base/migrations/0056_global_plugin_config.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('base', '0053_jitsiserver'),
+        ('base', '0055_alter_product_default_price_and_more'),
     ]
 
     operations = [


### PR DESCRIPTION
This PR resolves the migration numbering conflict where both `0054_global_plugin_config` and `0054_team_teamshifts_permissions` were created. `0054_global_plugin_config` has been renamed to `0056` and updated to depend on `0055_alter_product_default_price_and_more` to maintain the correct sequence.

## Summary by Sourcery

Bug Fixes:
- Resolve the migration numbering conflict by renaming the global plugin configuration migration to 0056 and restoring the correct migration dependency sequence.