### PR TITLE
chore: carry forward pydantic fix

### DIFF
--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -155,7 +155,6 @@ dependencies = [
     "pycparser>=2.23",
     "pycryptodome>=3.20.0",
     "pydantic>=2.13.3",
-    "pydantic-core>=2.48.0",
     "pydantic-settings>=2.15.0",
     "pygments>=2.19.1",
     "pyjwt>=2.13.0",

--- a/app/uv.lock
+++ b/app/uv.lock
@@ -1213,7 +1213,7 @@ dependencies = [
 [[package]]
 name = "eventyay-interpretation"
 version = "1.0.0"
-source = { git = "https://github.com/fossasia/eventyay-interpretation.git?rev=dev#c46f6d76d64a92c17ee376c9eda02d6717bcaaa5" }
+source = { git = "https://github.com/fossasia/eventyay-interpretation.git?rev=dev#fb544bb1e71c155dd0462a481f1a1dbcf761c331" }
 dependencies = [
     { name = "requests" },
 ]
@@ -1385,7 +1385,6 @@ dependencies = [
     { name = "pycparser" },
     { name = "pycryptodome" },
     { name = "pydantic" },
-    { name = "pydantic-core" },
     { name = "pydantic-settings" },
     { name = "pygments" },
     { name = "pyjwt" },
@@ -1623,7 +1622,6 @@ requires-dist = [
     { name = "pycparser", specifier = ">=2.23" },
     { name = "pycryptodome", specifier = ">=3.20.0" },
     { name = "pydantic", specifier = ">=2.13.3" },
-    { name = "pydantic-core", specifier = ">=2.48.0" },
     { name = "pydantic-settings", specifier = ">=2.15.0" },
     { name = "pyenchant", marker = "extra == 'docs'", specifier = ">=3.3.0" },
     { name = "pygments", specifier = ">=2.19.1" },


### PR DESCRIPTION
This PR synchronizes the `dev` branch with `main` to carry forward the pydantic dependency fix from #5038, which was accidentally merged directly into `main`.

## Summary by Sourcery

Carry the pydantic dependency fix from main into the development branch.

Enhancements:
- Align the development branch dependency configuration with main by removing the redundant direct pydantic-core dependency.

Chores:
- Synchronize the lockfile with the updated dependency set.