### PR TITLE
fix: renumber locale native-names migration to 0058

### DIFF
--- a/app/eventyay/base/migrations/0058_alter_locale_choices_native_names.py
+++ b/app/eventyay/base/migrations/0058_alter_locale_choices_native_names.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('base', '0056_global_plugin_config'),
+        ('base', '0057_user_default_organizer'),
     ]
 
     operations = [


### PR DESCRIPTION
Avoids the duplicate 0057 conflict with `user_default_organizer` on dev.

## Summary by Sourcery

Bug Fixes:
- Renumber the locale native-names migration to 0058 and update its dependency to follow the user default organizer migration, preventing a duplicate migration number conflict.