### PR TITLE
fix: hubspot bump to latest comit

### DIFF
--- a/app/uv.lock
+++ b/app/uv.lock
@@ -1203,7 +1203,7 @@ dependencies = [
 [[package]]
 name = "eventyay-hubspot"
 version = "1.0.0"
-source = { git = "https://github.com/fossasia/eventyay-hubspot.git?rev=dev#2f94688a781e71c193b983735e2471e1deb3b2a8" }
+source = { git = "https://github.com/fossasia/eventyay-hubspot.git?rev=dev#61d33822e99a54ac3492998ae126d1b25b01a929" }
 dependencies = [
     { name = "cryptography" },
     { name = "python-dotenv" },


### PR DESCRIPTION
61d33822e99a54ac3492998ae126d1b25b01a929

## Summary by Sourcery

Build:
- Update the locked Python dependency set in app/uv.lock to reflect the referenced HubSpot client commit.