### PR TITLE
fix(schedule): remove back button from session pages

### DIFF
--- a/app/eventyay/webapp/schedule/src/components/TalkDetail.vue
+++ b/app/eventyay/webapp/schedule/src/components/TalkDetail.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 .c-talk-detail
-	detail-back-nav
+	detail-back-nav(hide-back)
 		detail-top-actions(
 			:export-options="talkExportOptions",
 			:qrcodes-url="talkQrcodesUrl",

--- a/app/eventyay/webapp/schedule/src/components/TalkDetail.vue
+++ b/app/eventyay/webapp/schedule/src/components/TalkDetail.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 .c-talk-detail
-	detail-back-nav(hide-back)
+	detail-back-nav(:hide-back="true")
 		detail-top-actions(
 			:export-options="talkExportOptions",
 			:qrcodes-url="talkQrcodesUrl",


### PR DESCRIPTION
## Summary

- Remove the separate Back button from individual session pages.
- Preserve the existing session actions and event navigation.

## Verification

- Built the Docker development image successfully and the schedule frontend assets successfully.
- Confirmed the change uses the existing `hideBack` prop in the session-detail component.
- A full browser check was not completed because creating a local test event requires Stripe configuration unrelated to this change.

Fixes #5057

## Summary by Sourcery

Bug Fixes:
- Hide the separate back button on individual session detail pages while preserving existing navigation and session actions.