### PR TITLE
chore: bump teamshifts to latest dev

### DIFF
--- a/app/uv.lock
+++ b/app/uv.lock
@@ -1242,7 +1242,7 @@ dependencies = [
 [[package]]
 name = "eventyay-teamshifts"
 version = "0.1.0"
-source = { git = "https://github.com/fossasia/eventyay-teamshifts.git?rev=dev#512c35d425355b70ac3478aa4e6661359daca701" }
+source = { git = "https://github.com/fossasia/eventyay-teamshifts.git?rev=dev#f0ff452507a772765f82b0974a379bcb7b3a93ec" }
 
 [[package]]
 name = "eventyay-unified"


### PR DESCRIPTION
This PR bumps the eventyay-teamshifts dependency in `uv.lock` to the latest commit on the plugin's dev branch. (Includes permission models and signals, Tiptap editor, arrived status on the dashboard, and top navbar)

## Summary by Sourcery

Update the eventyay-teamshifts dependency to its latest development revision.

Enhancements:
- Update the eventyay-teamshifts dependency to the latest development revision, bringing in the plugin’s current functionality and improvements.

Build:
- Refresh the locked dependency revision in `app/uv.lock`.