### PR TITLE
ci: install gettext dependency for plugin translation compilation

### DIFF
--- a/.github/workflows/update-plugin-pins.yml
+++ b/.github/workflows/update-plugin-pins.yml
@@ -58,6 +58,9 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y gettext
+
       - name: Record current plugin pins
         id: old_pins
         run: |


### PR DESCRIPTION
Fixes CI failures during `uv sync` when building plugins (like `eventyay-socialmedia`) that require GNU gettext (`msgfmt`) to compile translations.

## Summary by Sourcery

Install gettext in the plugin pin update workflow to prevent CI failures when compiling plugin translations.

Bug Fixes:
- Install GNU gettext in the plugin pin update workflow so plugin translation compilation can complete successfully during dependency synchronization.

CI:
- Add gettext system dependency installation to the plugin pin update CI job.