### PR TITLE
fix : Add sorting for customer data fields and open invoice settings in same tab

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
@@ -107,11 +107,11 @@
                             <td class="text-center"><span class="text-muted">—</span></td>
                             <td class="text-center"><span class="text-muted">—</span></td>
                             <td class="dnd-container text-center text-nowrap">
-                                <span class="btn btn-default btn-sm dnd-sort-handle"><i class="fa fa-arrows"></i></span>
                                 <a href="{% url "control:event.settings.invoice" event=request.event.slug organizer=request.organizer.slug %}#tab-0-1-open"
                                    aria-label="{% translate 'See invoice settings' %}">
                                     {% translate "See invoice settings" %}
                                 </a>
+                                <span class="btn btn-default btn-sm dnd-sort-handle"><i class="fa fa-arrows"></i></span>
                             </td>
                         </tr>
                         {% endif %}

--- a/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
@@ -39,11 +39,11 @@
                             <th class="text-center">{% translate "Settings" %}</th>
                         </tr>
                     </thead>
-                    <tbody>
-                        {# E-mail #}
+                    <tbody data-dnd-url="{% url "control:event.products.questions.reorder" event=request.event.slug organizer=request.event.organizer.slug %}">
+                        {% for field_id in ordered_customer_fields %}
+                        {% if field_id == 'order_email' %}
                         {% with field=sform.order_email_asked_required %}
-                        {% if field %}
-                        <tr>
+                        <tr data-dnd-id="order_email">
                             <th id="{{ field.auto_id }}_label">{% translate "E-mail" %}</th>
                             <td class="text-center">
                                 <label class="toggle-switch" data-field-id="{{ field.auto_id }}"
@@ -64,16 +64,16 @@
                                 </div>
                             </td>
                             <td class="dnd-container text-center text-nowrap">
+                                <span class="btn btn-default btn-sm dnd-sort-handle"><i class="fa fa-arrows"></i></span>
                                 <a href="{% url 'control:event.products.orderforms.customerfield' organizer=request.event.organizer.slug event=request.event.slug field='order_email' %}" class="btn btn-default btn-sm" aria-label="{% translate 'Settings for E-mail' %}" title="{% translate 'Settings for E-mail' %}"><i class="fa fa-cog fa-fw"></i></a>
                             </td>
                         </tr>
-                        {% endif %}
                         {% endwith %}
+                        {% endif %}
 
-                        {# Phone number #}
+                        {% if field_id == 'order_phone' %}
                         {% with field=sform.order_phone_asked_required %}
-                        {% if field %}
-                        <tr>
+                        <tr data-dnd-id="order_phone">
                             <th id="{{ field.auto_id }}_label">{% translate "Phone number" %}</th>
                             <td class="text-center">
                                 <label class="toggle-switch" data-field-id="{{ field.auto_id }}"
@@ -94,26 +94,28 @@
                                 </div>
                             </td>
                             <td class="dnd-container text-center text-nowrap">
+                                <span class="btn btn-default btn-sm dnd-sort-handle"><i class="fa fa-arrows"></i></span>
                                 <a href="{% url 'control:event.products.orderforms.customerfield' organizer=request.event.organizer.slug event=request.event.slug field='order_phone' %}" class="btn btn-default btn-sm" aria-label="{% translate 'Settings for Phone number' %}" title="{% translate 'Settings for Phone number' %}"><i class="fa fa-cog fa-fw"></i></a>
                             </td>
                         </tr>
-                        {% endif %}
                         {% endwith %}
+                        {% endif %}
 
-                        {# Name and address - static link #}
-                        <tr>
+                        {% if field_id == 'name_address' %}
+                        <tr data-dnd-id="name_address">
                             <th>{% translate "Name and address" %}</th>
                             <td class="text-center"><span class="text-muted">—</span></td>
                             <td class="text-center"><span class="text-muted">—</span></td>
-                            <td class="text-center">
+                            <td class="dnd-container text-center text-nowrap">
+                                <span class="btn btn-default btn-sm dnd-sort-handle"><i class="fa fa-arrows"></i></span>
                                 <a href="{% url "control:event.settings.invoice" event=request.event.slug organizer=request.organizer.slug %}#tab-0-1-open"
-                                   target="_blank"
-                                   rel="noopener noreferrer"
-                                   aria-label="{% translate 'See invoice settings (opens in new tab)' %}">
+                                   aria-label="{% translate 'See invoice settings' %}">
                                     {% translate "See invoice settings" %}
                                 </a>
                             </td>
                         </tr>
+                        {% endif %}
+                        {% endfor %}
                     </tbody>
                 </table>
             </div>

--- a/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
@@ -64,7 +64,6 @@
                                 </div>
                             </td>
                             <td class="dnd-container text-center text-nowrap">
-                                <span class="btn btn-default btn-sm dnd-sort-handle"><i class="fa fa-arrows"></i></span>
                                 <a href="{% url 'control:event.products.orderforms.customerfield' organizer=request.event.organizer.slug event=request.event.slug field='order_email' %}" class="btn btn-default btn-sm" aria-label="{% translate 'Settings for E-mail' %}" title="{% translate 'Settings for E-mail' %}"><i class="fa fa-cog fa-fw"></i></a>
                             </td>
                         </tr>
@@ -94,7 +93,6 @@
                                 </div>
                             </td>
                             <td class="dnd-container text-center text-nowrap">
-                                <span class="btn btn-default btn-sm dnd-sort-handle"><i class="fa fa-arrows"></i></span>
                                 <a href="{% url 'control:event.products.orderforms.customerfield' organizer=request.event.organizer.slug event=request.event.slug field='order_phone' %}" class="btn btn-default btn-sm" aria-label="{% translate 'Settings for Phone number' %}" title="{% translate 'Settings for Phone number' %}"><i class="fa fa-cog fa-fw"></i></a>
                             </td>
                         </tr>
@@ -111,7 +109,6 @@
                                    aria-label="{% translate 'See invoice settings' %}">
                                     {% translate "See invoice settings" %}
                                 </a>
-                                <span class="btn btn-default btn-sm dnd-sort-handle"><i class="fa fa-arrows"></i></span>
                             </td>
                         </tr>
                         {% endif %}

--- a/app/eventyay/control/views/product.py
+++ b/app/eventyay/control/views/product.py
@@ -412,13 +412,16 @@ def reorder_questions(request, organizer, event):
     except (JSONDecodeError, KeyError, ValueError):
         return HttpResponseBadRequest('expected JSON: {ids:[]}')
 
-    input_questions = request.event.questions.filter(id__in=[i for i in ids if i.isdigit()])
+    digit_ids = [i for i in ids if i.isdigit()]
+    input_questions = request.event.questions.none()
+    if digit_ids:
+        input_questions = request.event.questions.filter(id__in=digit_ids)
 
-    if input_questions.count() != len([i for i in ids if i.isdigit()]):
-        raise Http404(_('Some of the provided question ids are invalid.'))
+        if input_questions.count() != len(digit_ids):
+            raise Http404(_('Some of the provided question ids are invalid.'))
 
-    if input_questions.count() != request.event.questions.count():
-        raise Http404(_('Not all questions have been selected.'))
+        if input_questions.count() != request.event.questions.count():
+            raise Http404(_('Not all questions have been selected.'))
 
     for q in input_questions:
         pos = ids.index(str(q.pk))
@@ -436,6 +439,9 @@ def reorder_questions(request, organizer, event):
         'zipcode',
         'city',
         'country',
+        'order_email',
+        'order_phone',
+        'name_address',
     ):
         if s in ids:
             system_question_order[s] = ids.index(s)
@@ -1816,6 +1822,17 @@ class OrderFormList(EventPermissionRequiredMixin, FormView):
             )
             for field_id in SYSTEM_QUESTION_FIELDS
         }
+
+        customer_field_ids = ['order_email', 'order_phone', 'name_address']
+        customer_field_order = []
+        for idx, field_id in enumerate(customer_field_ids):
+            if system_question_order and field_id in system_question_order and system_question_order[field_id] >= 0:
+                position = system_question_order[field_id]
+            else:
+                position = idx
+            customer_field_order.append((field_id, position))
+        customer_field_order.sort(key=lambda x: x[1])
+        ctx['ordered_customer_fields'] = [field_id for field_id, _ in customer_field_order]
 
         return ctx
 

--- a/app/eventyay/presale/forms/checkout.py
+++ b/app/eventyay/presale/forms/checkout.py
@@ -1,4 +1,5 @@
 import logging
+from collections import OrderedDict
 from itertools import chain
 
 from django import forms
@@ -111,6 +112,28 @@ class ContactForm(forms.Form):
             for key, value in response.items():
                 # We need to be this explicit, since OrderedDict.update does not retain ordering
                 self.fields[key] = value
+
+        system_question_order = event.settings.system_question_order or {}
+        customer_positions = []
+        if 'email' in self.fields:
+            customer_positions.append((system_question_order.get('order_email', 0), 'email'))
+            if 'email_repeat' in self.fields:
+                customer_positions.append((system_question_order.get('order_email', 0), 'email_repeat'))
+        if 'phone' in self.fields:
+            customer_positions.append((system_question_order.get('order_phone', 1), 'phone'))
+
+        customer_positions.sort(key=lambda x: x[0])
+
+        new_fields = OrderedDict()
+        for pos, name in customer_positions:
+            new_fields[name] = self.fields[name]
+
+        for name in self.fields:
+            if name not in new_fields:
+                new_fields[name] = self.fields[name]
+
+        self.fields = new_fields
+
         if self.all_optional:
             for k, v in self.fields.items():
                 v.required = False


### PR DESCRIPTION
## Summary

This PR adds drag-and-drop sorting support for **Customer data (once per order)** fields in the order form settings and ensures the configured order is reflected on the public checkout/order page.

It also fixes the **See invoice settings** link so that it opens in the same tab.

## Changes Made

### 1. Customer data fields are now sortable — `orderforms.html`

* Added `data-dnd-url` and `data-dnd-id` attributes to the customer data table rows for:

  * E-mail
  * Phone number
  * Name and address
* Added `dnd-sort-handle` drag handles before the settings/invoice links, matching the existing attendee data sorting UI.
* Reused the existing `reorder_questions` endpoint for customer data fields.

### 2. Reorder view extended — `control/views/product.py`

* Extended `reorder_questions` to track:

  * `order_email`
  * `order_phone`
  * `name_address`
* Stores their positions in `system_question_order`.
* Supports partial reordering so that reordering only customer fields does not affect attendee field ordering.

### 3. Ordered customer fields passed to the template — `control/views/product.py`

* `OrderFormList.get_context_data` now builds `ordered_customer_fields` from the saved `system_question_order`.
* Falls back to the default customer field order when no custom order is configured.

### 4. Public checkout respects customer field order — `presale/forms/checkout.py`

* `ContactForm` now reorders `email`, `email_repeat`, and `phone` based on `system_question_order`.
* The public checkout/order page therefore reflects the order configured by the organiser.

### 5. Invoice settings link fixed — `orderforms.html`

* Removed `target="_blank"` and `rel="noopener noreferrer"` from the **See invoice settings** link.
* Updated the `aria-label` to remove the “opens in new tab” text.
* Reordered the table cell so the invoice settings link appears before the drag handle.

## Acceptance Criteria

* [x] Organisers can reorder fields in **Customer data (once per order)**.
* [x] The customer data order is saved correctly.
* [x] The configured order is reflected on the public checkout/order page.
* [x] Attendee data sorting continues to work unchanged.
* [x] Existing field settings, active toggles, and required/optional settings continue to work.
* [x] **See invoice settings** opens in the same tab.

## Related Issue

Closes #5054

## Summary by Sourcery

Add configurable ordering for customer data fields and apply it consistently across order form settings and checkout.

New Features:
- Allow organisers to reorder customer data fields and preserve that order on the public checkout page.

Bug Fixes:
- Open the invoice settings link in the current tab.

Enhancements:
- Extend saved question ordering to support customer fields without disrupting attendee field ordering.