### PR TITLE
fix(mail): prevent noname attachment on emails without images

### DIFF
--- a/app/eventyay/base/services/mail.py
+++ b/app/eventyay/base/services/mail.py
@@ -371,7 +371,7 @@ def mail_send_task(
             attach_cid_images(html_message, cid_images, verify_ssl=True)
             email.attach_alternative(html_message, 'multipart/related')
         else:
-            email.attach_alternative(html, 'text/html')
+            email.attach_alternative(html_with_cid, 'text/html')
 
     if user:
         user = User.objects.get(pk=user)

--- a/app/eventyay/base/services/mail.py
+++ b/app/eventyay/base/services/mail.py
@@ -364,11 +364,14 @@ def mail_send_task(
 ) -> bool:
     email = CustomEmail(subject, body, sender, to=to, bcc=bcc, headers=headers)
     if html is not None:
-        html_message = SafeMIMEMultipart(_subtype='related', encoding=settings.DEFAULT_CHARSET)
         html_with_cid, cid_images = replace_images_with_cid_paths(html)
-        html_message.attach(SafeMIMEText(html_with_cid, 'html', settings.DEFAULT_CHARSET))
-        attach_cid_images(html_message, cid_images, verify_ssl=True)
-        email.attach_alternative(html_message, 'multipart/related')
+        if cid_images:
+            html_message = SafeMIMEMultipart(_subtype='related', encoding=settings.DEFAULT_CHARSET)
+            html_message.attach(SafeMIMEText(html_with_cid, 'html', settings.DEFAULT_CHARSET))
+            attach_cid_images(html_message, cid_images, verify_ssl=True)
+            email.attach_alternative(html_message, 'multipart/related')
+        else:
+            email.attach_alternative(html, 'text/html')
 
     if user:
         user = User.objects.get(pk=user)

--- a/app/eventyay/base/services/mail.py
+++ b/app/eventyay/base/services/mail.py
@@ -337,6 +337,8 @@ class CustomEmail(EmailMultiAlternatives):
         basetype, subtype = mimetype.split('/', 1)
         if basetype == 'multipart' and isinstance(content, SafeMIMEMultipart):
             return content
+        if basetype == 'text' and isinstance(content, SafeMIMEText):
+            return content
         return super()._create_mime_attachment(content, mimetype)
 
 
@@ -371,7 +373,7 @@ def mail_send_task(
             attach_cid_images(html_message, cid_images, verify_ssl=True)
             email.attach_alternative(html_message, 'multipart/related')
         else:
-            email.attach_alternative(html_with_cid, 'text/html')
+            email.attach_alternative(SafeMIMEText(html_with_cid, 'html', settings.DEFAULT_CHARSET), 'text/html')
 
     if user:
         user = User.objects.get(pk=user)
@@ -715,6 +717,7 @@ def convert_image_to_cid(image_src: str, cid_id: str, verify_ssl: bool = True) -
         image_type = re.findall(r'data:image/(\w+);base64', image_type)[0]
         mime_image = MIMEImage(image_content, _subtype=image_type, _encoder=encoder_linelength)
         mime_image.add_header('Content-Transfer-Encoding', 'base64')
+        guess_subtype = image_type
     elif image_src.startswith('data:'):
         logger.warning('Non-image MIME element %s[%s]', cid_id, image_src)
         return None
@@ -728,6 +731,9 @@ def convert_image_to_cid(image_src: str, cid_id: str, verify_ssl: bool = True) -
         mime_image = MIMEImage(response.content, _subtype=guess_subtype)
 
     mime_image.add_header('Content-ID', f'<{cid_id}>')
+    
+    filename = f"{cid_id}.{guess_subtype}" if guess_subtype else cid_id
+    mime_image.add_header('Content-Disposition', 'inline', filename=filename)
 
     return mime_image
 

--- a/app/eventyay/base/services/mail.py
+++ b/app/eventyay/base/services/mail.py
@@ -370,8 +370,11 @@ def mail_send_task(
         if cid_images:
             html_message = SafeMIMEMultipart(_subtype='related', encoding=settings.DEFAULT_CHARSET)
             html_message.attach(SafeMIMEText(html_with_cid, 'html', settings.DEFAULT_CHARSET))
-            attach_cid_images(html_message, cid_images, verify_ssl=True)
-            email.attach_alternative(html_message, 'multipart/related')
+            attached_count = attach_cid_images(html_message, cid_images, verify_ssl=True)
+            if attached_count > 0:
+                email.attach_alternative(html_message, 'multipart/related')
+            else:
+                email.attach_alternative(SafeMIMEText(html_with_cid, 'html', settings.DEFAULT_CHARSET), 'text/html')
         else:
             email.attach_alternative(SafeMIMEText(html_with_cid, 'html', settings.DEFAULT_CHARSET), 'text/html')
 
@@ -678,7 +681,8 @@ def replace_images_with_cid_paths(body_html: str) -> tuple[str, list[str]]:
     return str(email), cid_images
 
 
-def attach_cid_images(msg: SafeMIMEMultipart, cid_images: Sequence[str], verify_ssl: bool = True):
+def attach_cid_images(msg: SafeMIMEMultipart, cid_images: Sequence[str], verify_ssl: bool = True) -> int:
+    attached_count = 0
     if cid_images and len(cid_images) > 0:
         msg.mixed_subtype = 'mixed'
         for key, image in enumerate(cid_images):
@@ -686,8 +690,10 @@ def attach_cid_images(msg: SafeMIMEMultipart, cid_images: Sequence[str], verify_
             try:
                 if mime_image := convert_image_to_cid(image, cid, verify_ssl):
                     msg.attach(mime_image)
+                    attached_count += 1
             except (ValueError, IndexError, requests.RequestException, ssl.SSLError):
                 logger.exception('ERROR attaching CID image %s[%s]', cid, image)
+    return attached_count
 
 
 def encoder_linelength(msg):


### PR DESCRIPTION
Fixes #4963

## Summary by Sourcery

Ensure HTML emails use multipart related content only when inline images are successfully attached, avoiding noname attachments in image-free messages.

Bug Fixes:
- Prevent HTML emails without successfully embedded images from being sent as empty or unnamed multipart attachments.
- Fall back to a standard HTML alternative when inline image conversion fails or no inline images are present.

Enhancements:
- Preserve text MIME alternatives correctly and add inline image filenames based on their detected subtype.