### PR TITLE
chore: ignore legacy tests/video and tests/talk in pytest collection

### DIFF
--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -290,6 +290,7 @@ packages = ["eventyay"]
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "tests.tickets.settings"
 testpaths = ["tests"]
+norecursedirs = ["tests/video", "tests/talk"]
 asyncio_mode = "strict"
 asyncio_default_fixture_loop_scope = "function"
 filterwarnings = [


### PR DESCRIPTION
**Context:**
In PR #4780, we removed the `|| true` fallback from the `pytest --collect-only` step in the `update-plugin-pins.yml` workflow (as requested by reviewers so that actual failures would properly gate PR creation). 

**The Issue Exposed:**
Removing that band-aid exposed a pre-existing error: `pytest` was trying to collect tests inside the legacy `tests/video/` directory. That directory contains deprecated code attempting to import `venueless`, which crashes the CI with:
`ModuleNotFoundError: No module named 'venueless'`

**The Fix:**
According to the project guidelines, `video/`, `talk/`, and `venueless` are historical references only and should not be executed. Instead of ignoring all test collection errors with `|| true`, this PR addresses the root cause by adding `norecursedirs = ["tests/video", "tests/talk"]` to `pyproject.toml`. 

This explicitly tells `pytest` to skip these legacy directories entirely. CI will now correctly collect active tests and pass without tripping over deprecated legacy code.
