### PR TITLE
Enable copy user input by default and remove UI toggle

### DIFF
--- a/app/eventyay/base/configurations/default_setting.py
+++ b/app/eventyay/base/configurations/default_setting.py
@@ -2611,15 +2611,6 @@ Your {event} team"""
     'seating_minimal_distance': {'default': '0', 'type': float},
     'seating_allow_blocked_seats_for_channel': {'default': [], 'type': list},
     'seating_distance_within_row': {'default': 'False', 'type': bool},
-    'checkout_show_copy_answers_button': {
-        'default': 'True',
-        'type': bool,
-        'form_class': forms.BooleanField,
-        'serializer_class': serializers.BooleanField,
-        'form_kwargs': dict(
-            label=_('Show button to copy user input from other products'),
-        ),
-    },
     'startpage_header_image': {
         'default': None,
         'type': File,

--- a/app/eventyay/base/views/mixins.py
+++ b/app/eventyay/base/views/mixins.py
@@ -140,6 +140,20 @@ class BaseQuestionsViewMixin:
                 if pos not in storage:
                     storage[pos] = []
                 storage[pos].append(f)
+
+        groups = list(storage.values())
+        if groups:
+            first_group = groups[0]
+            for i, group in enumerate(groups):
+                if i == 0:
+                    group[0].pos.show_copy_answers_main_button = False
+                    continue
+
+                group[0].pos.show_copy_answers_main_button = any(
+                    set(form.fields.keys()) & set(first_group[addonidx].fields.keys())
+                    for addonidx, form in enumerate(group) if addonidx < len(first_group)
+                )
+
         return storage
 
     def save(self):

--- a/app/eventyay/control/forms/event.py
+++ b/app/eventyay/control/forms/event.py
@@ -640,7 +640,6 @@ class EventSettingsForm(SettingsForm):
         'allow_modifications',
         'last_order_modification_date',
         'allow_modifications_after_checkin',
-        'checkout_show_copy_answers_button',
         'primary_color',
         'theme_color_success',
         'theme_color_danger',
@@ -822,7 +821,6 @@ class OrderFormSettingsForm(EventSettingsForm):
         'order_email_asked_twice',
         'require_registered_account_for_tickets',
         'include_wikimedia_username',
-        'checkout_show_copy_answers_button',
     ]
 
     def __init__(self, *args, **kwargs):

--- a/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
+++ b/app/eventyay/control/templates/pretixcontrol/items/orderforms.html
@@ -496,7 +496,6 @@
 
         <fieldset>
             <legend>{% translate "Form settings" %}</legend>
-            {% bootstrap_field sform.checkout_show_copy_answers_button layout="control" %}
             {% bootstrap_field sform.require_registered_account_for_tickets layout="control" %}
             {% bootstrap_field sform.include_wikimedia_username layout="control" %}
         </fieldset>

--- a/app/eventyay/presale/templates/pretixpresale/event/checkout_questions.html
+++ b/app/eventyay/presale/templates/pretixpresale/event/checkout_questions.html
@@ -64,10 +64,8 @@
                             {% endif %}
                             {% if forloop.counter > 1 %}
                                 <span class="text-right flip">
-                                    {% if event.settings.checkout_show_copy_answers_button %}
                                         <button type="button" data-id="{{ forloop.counter0 }}" name="copy"
                                                 class="js-copy-answers btn btn-default btn-xs">{% trans "Copy answers from above" %}</button>
-                                    {% endif %}
                                     <i class="fa fa-angle-down collapse-indicator" aria-hidden="true"></i>
                                 </span>
                             {% else %}
@@ -130,7 +128,7 @@
                                 {% if form.pos.product != pos.product %}
                                     {# Add-Ons #}
                                     <legend>
-                                        {% if form.show_copy_answers_to_addon_button and event.settings.checkout_show_copy_answers_button %}
+                                        {% if form.show_copy_answers_to_addon_button %}
                                             <span class="pull-right flip">
                                                 <button type="button" data-id="{{ forloop.parentloop.counter0 }}" data-addonid="{{ forloop.counter0 }}" name="copy" class="js-copy-answers-addon btn btn-default btn-xs">{% trans "Copy answers" %}</button>
                                             </span>

--- a/app/eventyay/presale/templates/pretixpresale/event/checkout_questions.html
+++ b/app/eventyay/presale/templates/pretixpresale/event/checkout_questions.html
@@ -62,7 +62,7 @@
                             {% if pos.variation %}
                                 – {{ pos.variation.value|event_localize }}
                             {% endif %}
-                            {% if forloop.counter > 1 %}
+                            {% if forloop.counter > 1 and pos.show_copy_answers_main_button %}
                                 <span class="text-right flip">
                                         <button type="button" data-id="{{ forloop.counter0 }}" name="copy"
                                                 class="js-copy-answers btn btn-default btn-xs">{% trans "Copy answers from above" %}</button>


### PR DESCRIPTION
Resolves #5084.

This PR enables the **"Copy answers from above"** functionality by default during checkout and removes the associated configuration toggle from the event settings.

The copy-answers button is now available automatically when applicable, simplifying event configuration while improving the checkout experience for attendees.

### Changes made

* **Removed configuration setting:** Removed `checkout_show_copy_answers_button` from the default settings.
* **Updated forms:** Removed the toggle from both `EventSettingsForm` and `OrderFormSettingsForm`.
* **Cleaned up templates:**

  * Removed the configuration field from `orderforms.html`.
  * Updated `checkout_questions.html` so the copy-answers buttons are no longer controlle
<img width="1463" height="827" alt="Screenshot 2026-08-21 at 4 00 01 PM" src="https://github.com/user-attachments/assets/ed32f775-0463-4f58-855a-1e03a39e63fb" />
d by the removed setting and rely on the existing dynamic visibility logic.

## Summary by Sourcery

Make checkout answer copying available automatically when applicable and remove its configuration toggle.

Enhancements:
- Enable checkout answer-copy buttons based on applicable form relationships rather than an event setting.
- Remove the answer-copy configuration toggle from event settings and order-form administration.