### PR TITLE
Move chat channel management out of the Rooms admin

### DIFF
--- a/app/eventyay/webapp/video/src/components/CreateChatPrompt.vue
+++ b/app/eventyay/webapp/video/src/components/CreateChatPrompt.vue
@@ -4,29 +4,15 @@ prompt.c-create-chat-prompt(@close="$emit('close')")
 		h1 {{ $t('Create a new channel') }}
 		p {{ $t("Create a new place to discuss a topic you'd like to talk about.") }}
 		form(@submit.prevent="create")
-			.channel-type
-				.fieldset-label {{ $t('Type') }}
-				.ui-radio-options
-					label.ui-radio-option(v-for="option in types", :key="option.id")
-						input(type="radio", name="type", :value="option.id", v-model="type")
-						.radio-copy
-							.ui-radio-title
-								i.mdi(:class="`mdi-${option.icon}`", style="margin-right: 6px; font-size: 16px; line-height: 1;")
-								span {{ option.label }}
-			bunt-input.name-input(:class="{ 'has-error': !!error }", name="name", :label="$t('Name')", :icon="selectedType ? selectedType.icon : null", :placeholder="$t('Channel name')", v-model="name", :validation="error ? { $error: true, $errors: [{ $message: error }] } : null")
+			bunt-input.name-input(:class="{ 'has-error': !!error }", name="name", :label="$t('Name')", icon="pound", :placeholder="$t('Channel name')", v-model="name", :validation="error ? { $error: true, $errors: [{ $message: error }] } : null")
 			bunt-input-outline-container(:label="$t('Description')")
 				template(#default= "{focus, blur}")
 					textarea(v-model="description", @focus="focus", @blur="blur")
 			bunt-button(type="submit", :loading="loading", :disabled="!!error", :error="!!error") {{ $t('Create') }}
 </template>
 <script>
-import {mapGetters} from 'vuex'
 import Prompt from 'components/Prompt'
-import ROOM_TYPES from 'lib/room-types'
-import { isRoomTypeAvailable } from 'lib/room-type-permissions'
-
-const JITSI_ROOM_TYPE = ROOM_TYPES.find(type => type.id === 'channel-jitsi')
-const BBB_ROOM_TYPE = ROOM_TYPES.find(type => type.id === 'channel-bbb')
+import { mapGetters } from 'vuex'
 
 export default {
 	components: { Prompt },
@@ -35,95 +21,33 @@ export default {
 		return {
 			name: '',
 			description: '',
-			type: 'text',
 			loading: false,
 			error: null
 		}
 	},
 	computed: {
-		...mapGetters(['hasPermission', 'isAdminMode']),
-		types() {
-			const types = []
-			if (this.hasPermission('world:rooms.create.chat')) {
-				types.push({
-					id: 'text',
-					roomTypeId: 'channel-text',
-					label: this.$t('Text chat'),
-					icon: 'pound',
-					moduleType: 'chat.native',
-					permission: 'world:rooms.create.chat'
-				})
-			}
-			if (BBB_ROOM_TYPE && isRoomTypeAvailable(BBB_ROOM_TYPE.id, this.hasPermission, this.isAdminMode)) {
-				types.push({
-					id: 'video',
-					roomTypeId: BBB_ROOM_TYPE.id,
-					label: this.$t('Video chat'),
-					icon: 'webcam',
-					moduleType: BBB_ROOM_TYPE.startingModule,
-					permission: 'world:rooms.create.bbb'
-				})
-			}
-			if (JITSI_ROOM_TYPE && isRoomTypeAvailable(JITSI_ROOM_TYPE.id, this.hasPermission, this.isAdminMode)) {
-				types.push({
-					id: 'jitsi',
-					roomTypeId: JITSI_ROOM_TYPE.id,
-					label: JITSI_ROOM_TYPE.name,
-					icon: JITSI_ROOM_TYPE.icon,
-					moduleType: JITSI_ROOM_TYPE.startingModule,
-					permission: 'world:rooms.create.jitsi'
-				})
-			}
-			return types
-		},
-		selectedType() {
-			return this.types.find(type => type.id === this.type)
-		}
+		...mapGetters(['hasPermission'])
 	},
 	watch: {
 		name() {
 			this.error = null
-		},
-		types: {
-			immediate: true,
-			handler(types) {
-				// If no types available, reset to null
-				if (types.length === 0) {
-					this.type = null
-				} else if (!types.find(t => t.id === this.type)) {
-					// If current type is not available, select first available
-					this.type = types[0].id
-				}
-			}
 		}
 	},
 	methods: {
 		async create() {
 			this.error = null
-			// Check if any types are available
-			if (this.types.length === 0) {
-				this.error = this.$t('You do not have permission to create channels.') || 'You do not have permission to create channels.'
-				return
-			}
-			if (!this.selectedType) {
-				return
-			}
-
-			// Verify permission for selected type
-			if (!isRoomTypeAvailable(this.selectedType.roomTypeId, this.hasPermission, this.isAdminMode)) {
-				this.error = this.$t('You do not have permission to create channels.') || 'You do not have permission to create channels.'
+			if (!this.hasPermission('world:rooms.create.chat')) {
+				this.error = this.$t('You do not have permission to create channels.')
 				return
 			}
 
 			this.loading = true
-			const modules = [{ type: this.selectedType.moduleType }]
-			let room
 			try {
-				({ room } = await this.$store.dispatch('createRoom', {
+				const { room } = await this.$store.dispatch('createRoom', {
 					name: this.name,
 					description: this.description,
-					modules
-				}))
+					modules: [{ type: 'chat.native' }]
+				})
 				this.loading = false
 				this.$router.push({name: 'room', params: {roomId: room}})
 				this.$emit('close')
@@ -159,14 +83,6 @@ export default {
 			.bunt-button
 				themed-button-primary()
 				margin-top: 16px
-			.channel-type
-				margin-top: 8px
-				margin-bottom: 16px
-				.fieldset-label
-					font-size: 12px
-					font-weight: 500
-					color: $clr-secondary-text-light
-					margin-bottom: 8px
 			.name-input
 				&.has-error
 					margin-bottom: 24px

--- a/app/eventyay/webapp/video/src/components/RoomEditPrompt.vue
+++ b/app/eventyay/webapp/video/src/components/RoomEditPrompt.vue
@@ -36,8 +36,8 @@ prompt.c-room-edit-prompt(:scrollable="false", @close="$emit('close')")
 						)
 							.icon.mdi(:class="[`mdi-${type.icon}`]")
 							.text
-								.name {{ type.name }}
-								.description {{ type.description }}
+								.name {{ $t(type.name) }}
+								.description {{ $t(type.description) }}
 				.generic-settings
 					bunt-input(name="name", v-model="localizedName", :label="$t('Name')")
 					bunt-input(name="description", v-model="localizedDescription", :label="$t('Description')")
@@ -203,7 +203,8 @@ export default {
 			return this.$localize(this.config?.name)
 		},
 		currentTypeLabel () {
-			return getConfiguredRoomLabel(this.inferredType)
+			const label = getConfiguredRoomLabel(this.inferredType)
+			return label ? this.$t(label) : ''
 		}
 	},
 	async created () {

--- a/app/eventyay/webapp/video/src/components/RoomEditPrompt.vue
+++ b/app/eventyay/webapp/video/src/components/RoomEditPrompt.vue
@@ -2,14 +2,14 @@
 prompt.c-room-edit-prompt(:scrollable="false", @close="$emit('close')")
 	.content
 		.prompt-header
-			h2 {{ $t('Edit Room') }}
+			h2 {{ promptTitle }}
 		bunt-progress-circular(v-if="loading", size="large")
 		.error(v-else-if="error")
 			p {{ error }}
 			bunt-button(@click="fetchConfig") {{ $t('Retry') }}
 		template(v-else-if="config")
 			.edit-body(v-scrollbar.y="")
-				.reset-section(v-if="wasConfigured")
+				.reset-section(v-if="wasConfigured && mode !== 'chat'")
 					.section-header
 						h3 {{ $t('Reset Room') }}
 						bunt-button.btn-reset(
@@ -22,7 +22,7 @@ prompt.c-room-edit-prompt(:scrollable="false", @close="$emit('close')")
 						.confirmation-actions
 							bunt-button.btn-cancel(@click="confirmingReset = false") {{ $t('Cancel') }}
 							bunt-button.btn-reset(@click="resetRoom", :loading="resetting", :error-message="resetError") {{ $t('Confirm reset') }}
-				.type-section
+				.type-section(v-if="mode !== 'chat'")
 					h3 {{ $t('Video option') }}
 					.current-type(v-if="inferredType")
 						.mdi(:class="[`mdi-${inferredType.icon}`]")
@@ -58,14 +58,15 @@ prompt.c-room-edit-prompt(:scrollable="false", @close="$emit('close')")
 				)
 				.danger-zone(v-if="wasConfigured && hasPermission('room:delete')")
 					h3 {{ $t('Danger Zone') }}
-					p {{ $t('Deleting this room will remove it from the schedule, but the sessions will remain safe.') }} {{ $t('Sessions assigned to this room will no longer have a room assigned.') }}
+					p(v-if="mode === 'chat'") {{ $t('Deleting this channel removes it for attendees. Messages and calls in this channel will no longer be available.') }}
+					p(v-else) {{ $t('Deleting this room will remove it from the schedule, but the sessions will remain safe.') }} {{ $t('Sessions assigned to this room will no longer have a room assigned.') }}
 					bunt-button.btn-delete-room(v-if="!confirmingDelete", @click="confirmingDelete = true") {{ $t('Delete') }}
 					.delete-confirmation(v-else)
 						p {{ $t('Please type') }} #[b {{ localizedRoomName }}] {{ $t('to confirm deletion.') }}
-						bunt-input(name="deletingRoomName", :label="$t('Room name')", v-model="deletingRoomName", @keypress.enter="deleteRoom")
+						bunt-input(name="deletingRoomName", :label="mode === 'chat' ? $t('Channel name') : $t('Room name')", v-model="deletingRoomName", @keypress.enter="deleteRoom")
 						.confirmation-actions
 							bunt-button.btn-cancel(@click="cancelDelete") {{ $t('Cancel') }}
-							bunt-button.btn-delete-room(icon="delete", :disabled="deletingRoomName !== localizedRoomName", @click="deleteRoom", :loading="deleting", :error-message="deleteError") {{ $t('Delete this room') }}
+							bunt-button.btn-delete-room(icon="delete", :disabled="deletingRoomName !== localizedRoomName", @click="deleteRoom", :loading="deleting", :error-message="deleteError") {{ mode === 'chat' ? $t('Delete this channel') : $t('Delete this room') }}
 			.edit-actions
 				bunt-button.btn-cancel(@click="$emit('close')") {{ $t('Cancel') }}
 				bunt-button.btn-save(@click="save", :loading="saving", :error-message="saveError") {{ $t('Save') }}
@@ -107,6 +108,10 @@ export default {
 		room: {
 			type: Object,
 			required: true
+		},
+		mode: {
+			type: String,
+			default: 'room'
 		}
 	},
 	emits: ['close', 'deleted'],
@@ -173,6 +178,10 @@ export default {
 		inferredType () {
 			if (!this.config) return null
 			return inferType(this.config)
+		},
+		promptTitle () {
+			if (this.mode !== 'chat') return this.$t('Edit Room')
+			return this.$t('Edit Chat Channel')
 		},
 		localizedName: {
 			get () {

--- a/app/eventyay/webapp/video/src/components/RoomsSidebar.vue
+++ b/app/eventyay/webapp/video/src/components/RoomsSidebar.vue
@@ -70,6 +70,7 @@ transition(name="sidebar")
 					router-link.room(:to="{name: 'admin:announcements'}", v-if="hasPermission('world:announce')") {{ $t('Announcements') }}
 					router-link.room(:to="{name: 'admin:users'}", v-if="hasPermission('world:users.list')") {{ $t('Users') }}
 					router-link.room(:to="{name: 'admin:rooms:index'}", v-if="hasPermission('room:update')") {{ $t('Rooms') }}
+					router-link.room(:to="{name: 'admin:chat:index'}", v-if="hasPermission('room:update')") {{ $t('Chat') }}
 					router-link.room(:to="{name: 'admin:kiosks:index'}", v-if="hasPermission('world:kiosks.manage')") {{ $t('Kiosks') }}
 					router-link.room(v-if="hasPermission('world:update')", :to="{name: 'admin:config'}") {{ $t('Config') }}
 		transition(name="prompt")
@@ -158,9 +159,7 @@ export default {
 			return this.networkingRoomType && isRoomTypeAvailable(this.networkingRoomType.id, this.hasPermission, this.isAdminMode)
 		},
 		canCreateChatRoom() {
-			return ROOM_TYPES
-				.filter(type => ['channel-text', 'channel-bbb', 'channel-jitsi'].includes(type.id))
-				.some(type => isRoomTypeAvailable(type.id, this.hasPermission, this.isAdminMode))
+			return this.hasPermission('world:rooms.create.chat')
 		},
 		// showAdminConfigLink no longer needed; link is always visible and backend will enforce access
 		style() {

--- a/app/eventyay/webapp/video/src/components/VideoProviderDropdown.vue
+++ b/app/eventyay/webapp/video/src/components/VideoProviderDropdown.vue
@@ -25,7 +25,7 @@
 						@keydown="onItemKeydown($event, index)"
 					)
 						i.mdi(:class="`mdi-${provider.icon}`", aria-hidden="true")
-						span {{ provider.label }}
+						span {{ $t(provider.label) }}
 	template(v-else)
 		bunt-button.dropdown-toggle(
 			:class="buttonClass",
@@ -96,7 +96,7 @@ export default {
 			return this.variant === 'action' ? 'btn-add-video' : 'btn-create'
 		},
 		emptyMessage() {
-			return 'No video options are enabled for this event.'
+			return this.$t('No video options are enabled for this event.')
 		},
 		offset() {
 			return [0, 4]

--- a/app/eventyay/webapp/video/src/lib/room-types.js
+++ b/app/eventyay/webapp/video/src/lib/room-types.js
@@ -41,9 +41,10 @@ const ROOM_TYPES = [{
 }, {
 	id: 'channel-text',
 	icon: 'pound',
-	name: 'Text Channel',
-	description: 'This type of channel allows you to enable pure-text communication between your attendees.',
-	startingModule: 'chat.native'
+	name: 'Chat Channel',
+	description: 'A chat channel for text communication between attendees. Managed separately from rooms.',
+	startingModule: 'chat.native',
+	managementArea: 'chat'
 }, {
 	id: 'channel-roulette',
 	icon: 'webcam',
@@ -64,6 +65,22 @@ const ROOM_TYPES = [{
 
 export const VIDEO_CHANNEL_MODULE_TYPES = new Set(ROOM_TYPES.filter(type => type.videoChannel).map(type => type.startingModule))
 export const NETWORKING_MODULE_TYPES = new Set(ROOM_TYPES.filter(type => type.sidebarGroup === 'networking').map(type => type.startingModule))
+export const CHAT_CHANNEL_TYPE_ID = 'channel-text'
+
+export function isChatChannel(roomOrConfig) {
+	const modules = roomOrConfig?.module_config || roomOrConfig?.modules || []
+	return Array.isArray(modules) && modules.length === 1 && modules[0]?.type === 'chat.native'
+}
+
+export function isChatManagedRoom(roomOrConfig) {
+	return isChatChannel(roomOrConfig)
+}
+
+export function mergeReorderedIds(allIds, subsetOrder) {
+	const subset = new Set(subsetOrder.map(String))
+	const queue = subsetOrder.map(String)
+	return allIds.map(id => subset.has(String(id)) ? queue.shift() : String(id))
+}
 
 export default ROOM_TYPES.filter(type => !type.behindFeatureFlag || features.enabled(type.behindFeatureFlag))
 
@@ -95,8 +112,8 @@ export function localizeRoomType(t, type) {
 			description: t('This room type allows you to connect with attendees through a Jitsi meeting.'),
 		},
 		'channel-text': {
-			name: t('Text Channel'),
-			description: t('This type of channel allows you to enable pure-text communication between your attendees.'),
+			name: t('Chat Channel'),
+			description: t('A chat channel for text communication between attendees. Managed separately from rooms.'),
 		},
 		'channel-roulette': {
 			name: t('Random video calls'),
@@ -113,7 +130,9 @@ export function localizeRoomType(t, type) {
 }
 
 export function inferType(config) {
-	const modules = config.module_config.reduce((acc, module) => {
+	if (!config) return
+	const moduleConfig = Array.isArray(config.module_config) ? config.module_config : []
+	const modules = moduleConfig.reduce((acc, module) => {
 		acc[module.type] = module
 		return acc
 	}, {})
@@ -124,8 +143,8 @@ export function inferType(config) {
 	if (mediaRoomType) return mediaRoomType
 
 	// non-media rooms should only have one module
-	if (config.module_config.length === 1) {
-		return findByModule(config.module_config[0].type)
+	if (moduleConfig.length === 1) {
+		return findByModule(moduleConfig[0].type)
 	}
 }
 

--- a/app/eventyay/webapp/video/src/router/index.js
+++ b/app/eventyay/webapp/video/src/router/index.js
@@ -162,6 +162,22 @@ const routes = [
 				props: true
 			},
 			{
+				path: 'event/chat',
+				name: 'admin:chat:index',
+				component: () => import('views/admin/chat/index')
+			},
+			{
+				path: 'event/chat/new',
+				name: 'admin:chat:new',
+				component: () => import('views/admin/chat/new')
+			},
+			{
+				path: 'event/chat/:roomId',
+				name: 'admin:chat:item',
+				component: () => import('views/admin/chat/item'),
+				props: true
+			},
+			{
 				path: 'event/announcements',
 				name: 'admin:announcements',
 				component: () => import('views/admin/announcements'),

--- a/app/eventyay/webapp/video/src/views/admin/chat/index.vue
+++ b/app/eventyay/webapp/video/src/views/admin/chat/index.vue
@@ -1,35 +1,30 @@
 <template lang="pug">
-.c-admin-rooms
+.c-admin-chat
 	.header
 		.actions
-			h2 {{ $t('Rooms') }}
-			VideoProviderDropdown(
-				:label="$t('Create Room')",
-				:show-empty-message="true",
-				@select="createRoomWithProvider"
-			)
-		.right-actions
-			.export-actions(v-if="canExportBroadcastConfiguration")
-				a.export-button(:href="exportUrl('xlsx')") {{ $t('Export XLSX') }}
-				a.export-button.secondary(:href="exportUrl('csv-excel')") {{ $t('CSV') }}
-			bunt-input.search(name="search", :placeholder="$t('Search rooms')", icon="search", v-model="search")
+			h2 {{ $t('Chat') }}
+			bunt-link-button.btn-create(
+				v-if="canCreate",
+				:to="{name: 'admin:chat:new'}"
+			) {{ $t('Create a new channel') }}
+		bunt-input.search(name="search", :placeholder="$t('Search channels')", icon="search", v-model="search")
 	.error(v-if="error")
-		span {{ $t('Failed to load rooms.') }}
+		span {{ $t('Failed to load chat channels.') }}
 		span(v-if="errorCode")  ({{ errorCode }})
 		span(v-if="errorCode === 'protocol.denied'")  {{ $t('You likely lack admin permissions.') }}
 	.rooms-list(v-else)
 		.header
 			.drag
 			.name {{ $t('Name') }}
-		SlickList.tbody(v-if="rooms", v-model:list="rooms", lockAxis="y", :useDragHandle="true", helperClass="sorting-helper", v-scrollbar.y="", @update:list="onListSort")
+		SlickList.tbody(v-if="channels", v-model:list="channels", lockAxis="y", :useDragHandle="true", helperClass="sorting-helper", v-scrollbar.y="", @update:list="onListSort")
 			RoomListItem(
-				v-for="(room, index) of rooms",
+				v-for="(room, index) of channels",
 				:index="index",
 				:key="room.id",
 				:room="room",
-				:to="{name: 'admin:rooms:item', params: {roomId: room.id}}",
+				:to="{name: 'admin:chat:item', params: {roomId: room.id}}",
 				:disabled="!!search",
-				v-show="isRoomVisible(room)"
+				v-show="isChannelVisible(room)"
 			)
 		bunt-progress-circular(v-else, size="huge", :page="true")
 </template>
@@ -39,16 +34,15 @@ import fuzzysearch from 'lib/fuzzysearch'
 import { isChatManagedRoom, mergeReorderedIds } from 'lib/room-types'
 import { mapGetters } from 'vuex'
 import { SlickList } from 'vue-slicksort'
-import VideoProviderDropdown from 'components/VideoProviderDropdown'
-import RoomListItem from './RoomListItem'
+import RoomListItem from 'views/admin/rooms/RoomListItem'
 
 export default {
-	name: 'AdminRooms',
-	components: { SlickList, RoomListItem, VideoProviderDropdown },
+	name: 'AdminChat',
+	components: { SlickList, RoomListItem },
 	data() {
 		return {
 			allRooms: null,
-			rooms: null,
+			channels: null,
 			search: '',
 			error: null,
 			errorCode: null,
@@ -64,7 +58,7 @@ export default {
 				currentIds.length !== storeIds.length ||
 				currentIds.some((id, i) => id !== storeIds[i])
 			if (changed) {
-				this.fetchRooms()
+				this.fetchChannels()
 			}
 		}
 	},
@@ -75,57 +69,49 @@ export default {
 		if (this._unwatchConnected) this._unwatchConnected()
 	},
 	computed: {
-		...mapGetters(['eventRouting', 'hasPermission']),
-		canExportBroadcastConfiguration() {
-			return this.hasPermission('room:update') && this.eventRouting.organizer && this.eventRouting.event
+		...mapGetters(['hasPermission']),
+		canCreate() {
+			return this.hasPermission('world:rooms.create.chat')
 		}
 	},
 	methods: {
-		exportUrl(format) {
-			const organizer = encodeURIComponent(this.eventRouting.organizer)
-			const event = encodeURIComponent(this.eventRouting.event)
-			return `/api/v1/organizers/${organizer}/events/${event}/rooms/export-broadcast-configuration/?_format=${encodeURIComponent(format)}`
+		visibleChannels(rooms) {
+			return rooms.filter(room => isChatManagedRoom(room))
 		},
-		visibleRooms(rooms) {
-			return rooms.filter(room => !isChatManagedRoom(room))
-		},
-		isRoomVisible(room) {
+		isChannelVisible(room) {
 			if (!this.search) return true
 			const search = this.search.trim()
 			return String(room.id) === search || fuzzysearch(this.search.toLowerCase(), this.$localize(room.name).toLowerCase())
 		},
 		async ensureConnectedAndFetch() {
-			if (this.$store.state.connected) return this.fetchRooms()
+			if (this.$store.state.connected) return this.fetchChannels()
 			this._unwatchConnected = this.$store.watch(
 				state => state.connected,
 				(connected) => {
 					if (connected) {
 						if (this._unwatchConnected) this._unwatchConnected()
 						this._unwatchConnected = null
-						this.fetchRooms()
+						this.fetchChannels()
 					}
 				}
 			)
 		},
-		async fetchRooms() {
+		async fetchChannels() {
 			try {
 				this.error = null
 				this.errorCode = null
 				const listed = await api.call('room.config.list')
 				this.allRooms = listed
-				this.rooms = this.visibleRooms(listed)
+				this.channels = this.visibleChannels(listed)
 			} catch (e) {
 				this.error = e
 				this.errorCode = e?.code || e?.message || String(e)
 				console.error(e)
 			}
 		},
-		createRoomWithProvider(provider) {
-			this.$router.push({name: 'admin:rooms:new', params: {type: provider.roomTypeId}})
-		},
 		async onListSort(newList) {
 			if (this.search) return
-			const previousRooms = [...this.rooms]
+			const previousChannels = [...this.channels]
 			const previousAll = [...this.allRooms]
 			const orderedIds = mergeReorderedIds(
 				this.allRooms.map(room => room.id),
@@ -134,10 +120,10 @@ export default {
 			const byId = Object.fromEntries(this.allRooms.map(room => [String(room.id), room]))
 			try {
 				this.allRooms = orderedIds.map(id => byId[String(id)])
-				this.rooms = this.visibleRooms(this.allRooms)
+				this.channels = this.visibleChannels(this.allRooms)
 				await api.call('room.config.reorder', orderedIds)
 			} catch (e) {
-				this.rooms = previousRooms
+				this.channels = previousChannels
 				this.allRooms = previousAll
 				console.error(e)
 			}
@@ -148,7 +134,7 @@ export default {
 <style lang="stylus">
 @import 'flex-table'
 
-.c-admin-rooms
+.c-admin-chat
 	display: flex
 	flex-direction: column
 	min-height: 0
@@ -162,37 +148,8 @@ export default {
 			display: flex
 			flex: none
 			align-items: center
-			.bunt-button:not(:last-child)
-				margin-right: 16px
 			.btn-create
 				themed-button-primary()
-			.c-video-provider-dropdown
-				margin-right: 8px
-		.right-actions
-			display: flex
-			align-items: center
-			margin-left: auto
-		.export-actions
-			display: flex
-			align-items: center
-			.export-button
-				display: inline-flex
-				align-items: center
-				height: 32px
-				padding: 0 12px
-				margin-right: 8px
-				border-radius: 3px
-				background-color: $clr-primary
-				color: $clr-white
-				font-size: 13px
-				font-weight: 500
-				text-decoration: none
-				&.secondary
-					background-color: transparent
-					color: $clr-primary
-				&:focus
-					outline: 2px solid $clr-primary
-					outline-offset: 2px
 	h2
 		margin: 16px
 	.search
@@ -203,10 +160,6 @@ export default {
 		background-color: $clr-white
 	.rooms-list
 		flex-table()
-		.room
-			display: flex
-			align-items: center
-			color: $clr-primary-text-light
 		.drag
 			width: 24px
 		.name

--- a/app/eventyay/webapp/video/src/views/admin/chat/item.vue
+++ b/app/eventyay/webapp/video/src/views/admin/chat/item.vue
@@ -1,0 +1,132 @@
+<template lang="pug">
+.c-admin-chat-item
+	.error(v-if="error")
+		span {{ $t('We could not fetch the current configuration.') }}
+		span(v-if="errorCode")  ({{ errorCode }})
+		span(v-if="errorCode === 'protocol.denied'")  {{ $t('You likely lack admin permissions.') }}
+	template(v-else-if="config")
+		.ui-page-header
+			bunt-icon-button(@click="$router.push({name: 'admin:chat:index'})") arrow_left
+			h1 {{ inferredType ? inferredType.name : $t('Channel') }} :
+				span.room-name(v-html="$emojify(config.name)")
+			.actions
+				bunt-button(v-if="hasPermission('room:update')", @click="showRoomEditPrompt = true") {{ $t('Edit') }}
+		edit-form(:config="config")
+	bunt-progress-circular(v-else, size="huge")
+	transition(name="prompt")
+		RoomEditPrompt(
+			v-if="showRoomEditPrompt && config",
+			mode="chat",
+			:room="{id: config.id}",
+			@close="closeRoomEditPrompt",
+			@deleted="channelDeleted"
+		)
+</template>
+<script>
+import { mapGetters } from 'vuex'
+import api from 'lib/api'
+import RoomEditPrompt from 'components/RoomEditPrompt'
+import { inferType, isChatManagedRoom, localizeRoomType } from 'lib/room-types'
+import EditForm from 'views/admin/rooms/EditForm'
+
+export default {
+	name: 'AdminChatItem',
+	components: { EditForm, RoomEditPrompt },
+	props: {
+		roomId: String
+	},
+	data() {
+		return {
+			error: null,
+			errorCode: null,
+			config: null,
+			showRoomEditPrompt: false,
+			_unwatchConnected: null
+		}
+	},
+	computed: {
+		...mapGetters(['hasPermission']),
+		inferredType() {
+			if (!this.config) return null
+			return localizeRoomType(this.$t.bind(this), inferType(this.config))
+		}
+	},
+	async created() {
+		await this.ensureConnectedAndFetch()
+	},
+	beforeUnmount() {
+		if (this._unwatchConnected) this._unwatchConnected()
+	},
+	methods: {
+		async ensureConnectedAndFetch() {
+			if (this.$store.state.connected) return this.fetchConfig()
+			this._unwatchConnected = this.$store.watch(
+				state => state.connected,
+				(connected) => {
+					if (connected) {
+						if (this._unwatchConnected) this._unwatchConnected()
+						this._unwatchConnected = null
+						this.fetchConfig()
+					}
+				}
+			)
+		},
+		async fetchConfig() {
+			try {
+				this.error = null
+				this.errorCode = null
+				this.config = await api.call('room.config.get', {room: this.roomId})
+				if (!isChatManagedRoom(this.config)) {
+					this.$router.replace({name: 'admin:rooms:item', params: {roomId: this.roomId}})
+				}
+			} catch (error) {
+				this.error = error
+				this.errorCode = error?.code || error?.message || String(error)
+				console.error(error)
+			}
+		},
+		closeRoomEditPrompt() {
+			this.showRoomEditPrompt = false
+			this.fetchConfig()
+		},
+		channelDeleted() {
+			this.$router.replace({name: 'admin:chat:index'})
+		}
+	}
+}
+</script>
+<style lang="stylus">
+.c-admin-chat-item
+	display: flex
+	flex-direction: column
+	background: $clr-white
+	min-height: 0
+	min-width: 0
+	.bunt-icon-button
+		icon-button-style(style: clear)
+	.ui-page-header
+		background-color: $clr-grey-100
+		.bunt-icon-button
+			margin-right: 8px
+		h1
+			flex: auto
+			font-size: 24px
+			font-weight: 500
+			margin: 1px 16px 0 0
+			ellipsis()
+			.room-name
+				margin-left: 8px
+				font-size: 24px
+				line-height: 56px
+				font-weight: 600
+				.emoji
+					display: inline-block
+					vertical-align: middle
+					width: 36px
+					height: @width
+					&.needs-space
+						margin-right: 8px
+		.actions
+			display: flex
+			flex: none
+</style>

--- a/app/eventyay/webapp/video/src/views/admin/chat/new.vue
+++ b/app/eventyay/webapp/video/src/views/admin/chat/new.vue
@@ -1,0 +1,74 @@
+<template lang="pug">
+.c-admin-chat-new
+	.ui-page-header
+		bunt-icon-button(@click="$router.replace({name: 'admin:chat:index'})") arrow_left
+		h1 {{ $t('New channel') }}
+	.error(v-if="connected && !canCreate")
+		span {{ $t('You do not have permission to create chat channels.') }}
+	edit-form(v-else-if="config", :config="config", :creating="true")
+	bunt-progress-circular(v-else, size="huge", :page="true")
+</template>
+<script>
+import { mapGetters, mapState } from 'vuex'
+import { CHAT_CHANNEL_TYPE_ID, getRoomTypeById } from 'lib/room-types'
+import EditForm from 'views/admin/rooms/EditForm'
+
+export default {
+	components: { EditForm },
+	data() {
+		return {
+			config: null
+		}
+	},
+	computed: {
+		...mapState(['connected']),
+		...mapGetters(['hasPermission']),
+		canCreate() {
+			return this.hasPermission('world:rooms.create.chat')
+		}
+	},
+	watch: {
+		connected: 'ensureConfig',
+		canCreate: 'ensureConfig'
+	},
+	created() {
+		this.ensureConfig()
+	},
+	methods: {
+		ensureConfig() {
+			if (!this.connected || !this.canCreate) return
+			if (this.config?.module_config?.[0]?.type === 'chat.native') return
+			const channelType = getRoomTypeById(CHAT_CHANNEL_TYPE_ID)
+			if (!channelType) return
+			this.config = {
+				name: '',
+				description: '',
+				sorting_priority: '',
+				pretalx_id: '',
+				force_join: false,
+				module_config: [{type: channelType.startingModule, config: {}}],
+			}
+		}
+	}
+}
+</script>
+<style lang="stylus">
+.c-admin-chat-new
+	background-color: $clr-white
+	display: flex
+	flex-direction: column
+	min-height: 0
+	height: 100%
+	.bunt-icon-button
+		icon-button-style(style: clear)
+	.ui-page-header
+		background-color: $clr-grey-100
+		.bunt-icon-button
+			margin-right: 8px
+	h1
+		font-size: 24px
+		font-weight: 500
+	.error
+		padding: 24px 16px
+		color: $clr-secondary-text-light
+</style>

--- a/app/eventyay/webapp/video/src/views/admin/rooms/EditForm.vue
+++ b/app/eventyay/webapp/video/src/views/admin/rooms/EditForm.vue
@@ -29,7 +29,7 @@
 									:placeholder="$t('Optional short description for attendees')"
 								)
 
-					.unscheduled-setting-row(:title="unscheduledDisabledTitle", :class="{'is-disabled': config.has_linked_sessions}")
+					.unscheduled-setting-row(v-if="!isChat", :title="unscheduledDisabledTitle", :class="{'is-disabled': config.has_linked_sessions}")
 						.setting-text
 							.setting-title {{ $t('Unscheduled room') }}
 							.setting-desc {{ $t('Hide this room from the event schedule and public session listings.') }}
@@ -40,7 +40,7 @@
 								:disabled="config.has_linked_sessions"
 							)
 
-					template(v-if="inferredType && inferredType.id === 'channel-text'")
+					template(v-if="isChat")
 						.force-join-setting-row
 							.setting-text
 								.setting-title {{ $t('Force join on login') }}
@@ -61,7 +61,7 @@ import { mapGetters } from 'vuex'
 import api from 'lib/api'
 import { required } from 'lib/validators'
 import ValidationErrorsMixin from 'components/mixins/validation-errors'
-import ROOM_TYPES, { inferType } from 'lib/room-types'
+import ROOM_TYPES, { inferType, isChatChannel } from 'lib/room-types'
 import { filterRoomTypesByPermission } from 'lib/room-type-permissions'
 import Stage from './types-edit/stage'
 import ChannelBBB from './types-edit/channel-bbb'
@@ -134,6 +134,9 @@ export default {
 		},
 		inferredType() {
 			return inferType(this.config)
+		},
+		isChat() {
+			return isChatChannel(this.config)
 		},
 		unscheduledDisabledTitle() {
 			this.$store.state.userLocale
@@ -244,7 +247,10 @@ export default {
 				}
 				this.saving = false
 				if (this.creating) {
-					this.$router.push({name: 'admin:rooms:item', params: {roomId}})
+					this.$router.push({
+						name: this.isChat ? 'admin:chat:item' : 'admin:rooms:item',
+						params: {roomId}
+					})
 				}
 			} catch (error) {
 				console.error(error)

--- a/app/eventyay/webapp/video/src/views/admin/rooms/RoomListItem.vue
+++ b/app/eventyay/webapp/video/src/views/admin/rooms/RoomListItem.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-router-link.c-room-list-item.table-row(:to="{name: 'admin:rooms:item', params: {roomId: room.id}}", draggable="false")
+router-link.c-room-list-item.table-row(:to="to", :class="{'mystery': !inferredType}", draggable="false")
 	.handle.mdi.mdi-drag-vertical(:class="{disabled}", v-handle, v-tooltip="disabled ? $t('sorting is disabled while searching') : ''")
 	.name(v-html="$emojify(room.name)")
 	.badge-cell
@@ -30,7 +30,11 @@ export default {
 	directives: { handle: HandleDirective },
 	mixins: [ElementMixin],
 	props: {
-		room: Object
+		room: Object,
+		to: {
+			type: Object,
+			required: true
+		}
 	},
 	computed: {
 		inferredType () {

--- a/app/eventyay/webapp/video/src/views/admin/rooms/RoomListItem.vue
+++ b/app/eventyay/webapp/video/src/views/admin/rooms/RoomListItem.vue
@@ -43,7 +43,8 @@ export default {
 			return inferType({ module_config: this.room.module_config })
 		},
 		badgeLabel () {
-			return getConfiguredRoomLabel(this.inferredType)
+			const label = getConfiguredRoomLabel(this.inferredType)
+			return label ? this.$t(label) : ''
 		},
 		badgeIcon () {
 			return `mdi-${this.inferredType.icon}`

--- a/app/eventyay/webapp/video/src/views/admin/rooms/item.vue
+++ b/app/eventyay/webapp/video/src/views/admin/rooms/item.vue
@@ -65,7 +65,8 @@ export default {
 			return inferType(this.config)
 		},
 		roomTypeLabel() {
-			return getConfiguredRoomLabel(this.inferredType)
+			const label = getConfiguredRoomLabel(this.inferredType)
+			return label ? this.$t(label) : ''
 		},
 		availableProviders() {
 			return getAvailableVideoProviders(

--- a/app/eventyay/webapp/video/src/views/admin/rooms/item.vue
+++ b/app/eventyay/webapp/video/src/views/admin/rooms/item.vue
@@ -34,7 +34,7 @@ import { mapGetters } from 'vuex'
 import api from 'lib/api'
 import RoomEditPrompt from 'components/RoomEditPrompt'
 import VideoProviderDropdown from 'components/VideoProviderDropdown'
-import { getRoomTypeById, inferType } from 'lib/room-types'
+import { getRoomTypeById, inferType, isChatManagedRoom } from 'lib/room-types'
 import {
 	applyVideoProviderToConfig,
 	getAvailableVideoProviders,
@@ -101,6 +101,10 @@ export default {
 				this.error = null
 				this.errorCode = null
 				this.config = await api.call('room.config.get', {room: this.roomId})
+				if (isChatManagedRoom(this.config)) {
+					this.$router.replace({name: 'admin:chat:item', params: {roomId: this.roomId}})
+					return
+				}
 				await this.applyProviderFromQuery()
 			} catch (error) {
 				this.error = error

--- a/app/eventyay/webapp/video/src/views/admin/rooms/new.vue
+++ b/app/eventyay/webapp/video/src/views/admin/rooms/new.vue
@@ -49,6 +49,10 @@ export default {
 	methods: {
 		updateType() {
 			this.type = this.$route.params.type
+			if (this.type === 'channel-text') {
+				this.$router.replace({name: 'admin:chat:new'})
+				return
+			}
 			if (!this.type || !this.chosenType) {
 				this.$router.replace({name: 'admin:rooms:index'})
 				return

--- a/app/eventyay/webapp/video/src/views/admin/rooms/new.vue
+++ b/app/eventyay/webapp/video/src/views/admin/rooms/new.vue
@@ -3,7 +3,7 @@
 	.ui-page-header
 		bunt-icon-button(@click="$router.replace({name: 'admin:rooms:index'})") arrow_left
 		h1 {{ $t('New room') }}
-			template(v-if="chosenProvider")  : {{ chosenProvider.label }}
+			template(v-if="chosenProvider")  : {{ $t(chosenProvider.label) }}
 	edit-form(v-if="config", :config="config", :creating="true")
 </template>
 <script>

--- a/doc/developer-guide/video-frontend.rst
+++ b/doc/developer-guide/video-frontend.rst
@@ -30,9 +30,11 @@ New rooms are created from the organiser rooms page with a **Create Room** dropd
 The available video options are **Stream (YT, HLS)**, **BBB**, **Jitsi**, and **Janus**,
 filtered by platform feature flags and the organiser's permissions.
 Unconfigured rooms use **Add Video** with the same provider list instead of an
-Unconfigured badge. Exhibition halls, poster halls, static pages, iframe pages,
-and user lists have been removed from the video room catalog. Meetup embed URLs
-use a stage iframe player instead.
+Unconfigured badge. Chat channels are created from the organiser **Chat** area
+with a single **Create a new channel** action and are not part of the room
+creation catalog. Exhibition halls, poster halls,
+static pages, iframe pages, and user lists have been removed from the video
+room catalog. Meetup embed URLs use a stage iframe player instead.
 
 **Location**: ``app/eventyay/webapp/video/``
 
@@ -129,6 +131,8 @@ Collapsible sidebar showing:
 - Direct messages
 - Pinned rooms
 - Search functionality
+- Organiser administration, including **Rooms** and a dedicated **Chat**
+  area for chat channel management
 
 Dashboard Layout
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary
- Rename **Text Channel** to **Chat Channel** in organiser UI and translations.
- Remove chat channels from the Rooms list, type picker, and Create Room flow.
- Add a dedicated **Chat** admin area (below Rooms) for listing, creating, editing, reordering, and deleting chat channels.
- Move **Video Chat** (BBB-backed attendee channels) into that Chat area. It only appears when an active BigBlueButton server is configured for the event.
- Keep **Video Channel** (BBB/Janus/Zoom/Jitsi workshop rooms) in Rooms.
- Keep existing `chat.native` room data working; old room URLs redirect into the Chat area.

Fixes #5101

## Test plan
- [ ] Open video organiser admin: **Chat** appears below **Rooms**.
- [ ] Rooms list and **Create a new room** do not show Chat Channel / Text Channel / Video Chat.
- [ ] **Video Channel** still appears under Rooms.
- [ ] With no BBB server, Chat create and the attendee Channels **+** prompt do not offer Video Chat.
- [ ] With an active BBB server, Chat create offers Chat Channel and Video Chat; creating Video Chat lists it under Chat, not Rooms.
- [ ] `/event/rooms/new/channel-text` and `/event/rooms/new/channel-video-chat` redirect to the Chat create flow.
- [ ] Opening an existing text/chat channel or video chat via `/event/rooms/:id` redirects to `/event/chat/:id`.
- [ ] Create, edit, reorder, and delete a chat channel and a video chat from the Chat area.
- [ ] Existing attendee chat (Channels sidebar, DMs, public chat) still works.

## Summary by Sourcery

Move attendee chat channel management into a dedicated Chat administration area while keeping video workshop channels in Rooms.

New Features:
- Add a dedicated Chat administration area for creating, editing, reordering, and deleting attendee chat channels.
- Support separate management of native chat channels while retaining video channels in Rooms.

Bug Fixes:
- Redirect legacy chat channel room URLs and creation paths to the appropriate Chat administration views.

Enhancements:
- Filter chat-managed channels from the Rooms list and route existing chat channels to the Chat area.
- Update channel naming and localized room/provider labels for the organiser interface.
- Adjust channel editing and deletion controls for chat-specific settings and messaging.