### PR TITLE
Replace Choose room type with Create Room video provider dropdown

### DIFF
--- a/app/eventyay/webapp/video/src/components/RoomEditPrompt.vue
+++ b/app/eventyay/webapp/video/src/components/RoomEditPrompt.vue
@@ -23,10 +23,10 @@ prompt.c-room-edit-prompt(:scrollable="false", @close="$emit('close')")
 							bunt-button.btn-cancel(@click="confirmingReset = false") Cancel
 							bunt-button.btn-reset(@click="resetRoom", :loading="resetting", :error-message="resetError") Confirm reset
 				.type-section
-					h3 Room Type
+					h3 Video option
 					.current-type(v-if="inferredType")
 						.mdi(:class="[`mdi-${inferredType.icon}`]")
-						span {{ inferredType.name }}
+						span {{ currentTypeLabel }}
 					.type-picker
 						.type-option(
 							v-for="type of availableRoomTypes",
@@ -75,9 +75,13 @@ import { markRaw } from 'vue'
 import { mapGetters } from 'vuex'
 import api from 'lib/api'
 import Prompt from 'components/Prompt'
-import ROOM_TYPES, { inferType } from 'lib/room-types'
-import { filterRoomTypesByPermission } from 'lib/room-type-permissions'
-import { PLAYBACK_MODE_SCHEDULE_DRIVEN } from 'lib/stage-streams'
+import { getRoomTypeById, inferType } from 'lib/room-types'
+import {
+	getAvailableVideoProviders,
+	getConfiguredRoomLabel,
+	applyVideoProviderToConfig,
+} from 'lib/video-providers'
+import features from 'features'
 import Stage from 'views/admin/rooms/types-edit/stage'
 import ChannelBBB from 'views/admin/rooms/types-edit/channel-bbb'
 import ChannelJanus from 'views/admin/rooms/types-edit/channel-janus'
@@ -111,7 +115,6 @@ export default {
 			deletingRoomName: '',
 			deleting: false,
 			deleteError: null,
-			allRoomTypes: ROOM_TYPES,
 			typeComponents: markRaw({
 				stage: Stage,
 				'page-landing': PageLanding,
@@ -126,7 +129,23 @@ export default {
 	computed: {
 		...mapGetters(['hasPermission', 'isAdminMode']),
 		availableRoomTypes () {
-			return filterRoomTypesByPermission(this.allRoomTypes, this.hasPermission, this.isAdminMode)
+			const videoTypes = getAvailableVideoProviders(
+				this.hasPermission,
+				this.isAdminMode,
+				(flag) => features.enabled(flag)
+			).map(provider => {
+				const type = getRoomTypeById(provider.roomTypeId)
+				if (!type) return null
+				return {
+					...type,
+					name: provider.label,
+					description: provider.description
+				}
+			}).filter(Boolean)
+			if (this.inferredType && !videoTypes.some(type => type.id === this.inferredType.id)) {
+				return [this.inferredType, ...videoTypes]
+			}
+			return videoTypes
 		},
 		modules () {
 			if (!this.config) return {}
@@ -157,18 +176,15 @@ export default {
 		},
 		localizedRoomName () {
 			return this.$localize(this.config?.name)
+		},
+		currentTypeLabel () {
+			return getConfiguredRoomLabel(this.inferredType)
 		}
 	},
 	async created () {
 		await this.fetchConfig()
 	},
 	methods: {
-		getStartingModuleConfig (type) {
-			if (type.id === 'stage') {
-				return { playback_mode: PLAYBACK_MODE_SCHEDULE_DRIVEN }
-			}
-			return {}
-		},
 		async fetchConfig () {
 			this.loading = true
 			this.error = null
@@ -185,7 +201,7 @@ export default {
 		},
 		changeType (type) {
 			if (this.inferredType && this.inferredType.id === type.id) return
-			this.config.module_config = [{ type: type.startingModule, config: this.getStartingModuleConfig(type) }]
+			applyVideoProviderToConfig(this.config, type)
 		},
 		async resetRoom () {
 			this.resetError = null

--- a/app/eventyay/webapp/video/src/components/VideoProviderDropdown.vue
+++ b/app/eventyay/webapp/video/src/components/VideoProviderDropdown.vue
@@ -1,0 +1,219 @@
+<template lang="pug">
+.c-video-provider-dropdown(v-if="canManage", @click.stop, @keydown.stop)
+	template(v-if="providers.length")
+		menu-dropdown(v-model="open", :placement="placement", :offset="offset")
+			template(#button="{toggle}")
+				bunt-button.dropdown-toggle(
+					:class="buttonClass",
+					:aria-haspopup="'menu'",
+					:aria-expanded="open ? 'true' : 'false'",
+					:aria-controls="menuId",
+					@click="onToggle($event, toggle)",
+					@keydown="onButtonKeydown($event, toggle)"
+				)
+					span {{ label }}
+					i.mdi.mdi-menu-down(aria-hidden="true")
+			template(#menu)
+				.provider-menu.not-menu-item(:id="menuId", role="menu", :aria-label="label")
+					button.provider-option(
+						v-for="(provider, index) of providers",
+						:key="provider.id",
+						type="button",
+						role="menuitem",
+						:ref="el => setItemRef(el, index)",
+						@click="selectProvider(provider)",
+						@keydown="onItemKeydown($event, index)"
+					)
+						i.mdi(:class="`mdi-${provider.icon}`", aria-hidden="true")
+						span {{ provider.label }}
+	template(v-else)
+		bunt-button.dropdown-toggle(
+			:class="buttonClass",
+			disabled,
+			:title="emptyMessage"
+		)
+			span {{ label }}
+			i.mdi.mdi-menu-down(aria-hidden="true")
+		p.empty-message(v-if="showEmptyMessage") {{ emptyMessage }}
+</template>
+<script>
+import { mapGetters } from 'vuex'
+import features from 'features'
+import MenuDropdown from 'components/MenuDropdown'
+import {
+	canManageVideoRooms,
+	getAvailableVideoProviders
+} from 'lib/video-providers'
+
+let dropdownId = 0
+
+export default {
+	name: 'VideoProviderDropdown',
+	components: { MenuDropdown },
+	props: {
+		label: {
+			type: String,
+			required: true
+		},
+		variant: {
+			type: String,
+			default: 'primary'
+		},
+		showEmptyMessage: {
+			type: Boolean,
+			default: false
+		},
+		placement: {
+			type: String,
+			default: 'bottom-start'
+		}
+	},
+	emits: ['select'],
+	data() {
+		return {
+			open: false,
+			menuId: `video-provider-menu-${++dropdownId}`,
+			itemRefs: []
+		}
+	},
+	computed: {
+		...mapGetters(['hasPermission', 'isAdminMode']),
+		canManage() {
+			return canManageVideoRooms(this.hasPermission)
+		},
+		providers() {
+			return getAvailableVideoProviders(
+				this.hasPermission,
+				this.isAdminMode,
+				(flag) => features.enabled(flag)
+			)
+		},
+		buttonClass() {
+			return this.variant === 'action' ? 'btn-add-video' : 'btn-create'
+		},
+		emptyMessage() {
+			return 'No video options are enabled for this event.'
+		},
+		offset() {
+			return [0, 4]
+		}
+	},
+	methods: {
+		setItemRef(el, index) {
+			if (el) this.itemRefs[index] = el
+		},
+		onToggle(event, toggle) {
+			const wasOpen = this.open
+			toggle(event)
+			if (!wasOpen) {
+				this.$nextTick(() => this.focusItem(0))
+			}
+		},
+		onButtonKeydown(event, toggle) {
+			if (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ') {
+				event.preventDefault()
+				if (!this.open) toggle(event)
+				this.$nextTick(() => this.focusItem(0))
+			}
+			if (event.key === 'Escape' && this.open) {
+				event.preventDefault()
+				this.open = false
+			}
+		},
+		onItemKeydown(event, index) {
+			if (event.key === 'Escape') {
+				event.preventDefault()
+				this.open = false
+				this.$el.querySelector('.dropdown-toggle')?.focus?.()
+				return
+			}
+			if (event.key === 'ArrowDown') {
+				event.preventDefault()
+				this.focusItem(index + 1)
+				return
+			}
+			if (event.key === 'ArrowUp') {
+				event.preventDefault()
+				this.focusItem(index - 1)
+				return
+			}
+			if (event.key === 'Home') {
+				event.preventDefault()
+				this.focusItem(0)
+				return
+			}
+			if (event.key === 'End') {
+				event.preventDefault()
+				this.focusItem(this.providers.length - 1)
+				return
+			}
+			if (event.key === 'Enter' || event.key === ' ') {
+				event.preventDefault()
+				this.selectProvider(this.providers[index])
+			}
+		},
+		focusItem(index) {
+			if (!this.providers.length) return
+			const nextIndex = (index + this.providers.length) % this.providers.length
+			this.itemRefs[nextIndex]?.focus?.()
+		},
+		selectProvider(provider) {
+			this.open = false
+			this.$emit('select', provider)
+		}
+	}
+}
+</script>
+<style lang="stylus">
+.c-video-provider-dropdown
+	position: relative
+	display: inline-flex
+	flex-direction: column
+	align-items: flex-end
+	.dropdown-toggle
+		display: inline-flex
+		align-items: center
+		gap: 4px
+		&.btn-create
+			themed-button-primary()
+		&.btn-add-video
+			themed-button-secondary()
+			height: 28px
+			padding: 0 10px
+			font-size: 12px
+			line-height: 28px
+		.mdi-menu-down
+			font-size: 18px
+			margin-right: -4px
+	.empty-message
+		margin: 8px 0 0
+		max-width: 280px
+		font-size: 12px
+		line-height: 16px
+		color: $clr-secondary-text-light
+		text-align: right
+	.provider-menu
+		display: flex
+		flex-direction: column
+		min-width: 220px
+	.provider-option
+		display: flex
+		align-items: center
+		gap: 8px
+		width: 100%
+		height: 36px
+		padding: 0 16px
+		border: 0
+		background: transparent
+		color: inherit
+		font: inherit
+		text-align: left
+		cursor: pointer
+		&:hover,
+		&:focus
+			background-color: var(--clr-input-primary-bg, $clr-grey-50)
+			color: var(--clr-input-primary-fg, $clr-primary-text-light)
+			outline: none
+		.mdi
+			font-size: 18px
+</style>

--- a/app/eventyay/webapp/video/src/lib/room-types.js
+++ b/app/eventyay/webapp/video/src/lib/room-types.js
@@ -67,6 +67,10 @@ export const NETWORKING_MODULE_TYPES = new Set(ROOM_TYPES.filter(type => type.si
 
 export default ROOM_TYPES.filter(type => !type.behindFeatureFlag || features.enabled(type.behindFeatureFlag))
 
+export function getRoomTypeById(id) {
+	return ROOM_TYPES.find(type => type.id === id) || null
+}
+
 export function inferType(config) {
 	const modules = config.module_config.reduce((acc, module) => {
 		acc[module.type] = module

--- a/app/eventyay/webapp/video/src/lib/video-providers.js
+++ b/app/eventyay/webapp/video/src/lib/video-providers.js
@@ -1,0 +1,95 @@
+import { isRoomTypeAvailable } from './room-type-permissions.js'
+
+export const VIDEO_CREATE_PROVIDERS = [
+	{
+		id: 'stream',
+		roomTypeId: 'stage',
+		label: 'Stream (YT, HLS)',
+		roomKind: 'Stage',
+		shortLabel: 'Stream',
+		icon: 'theater',
+		description: 'Present a live HLS or YouTube stream, optionally with chat and Q&A.',
+		featureFlag: null
+	},
+	{
+		id: 'bbb',
+		roomTypeId: 'channel-bbb',
+		label: 'BBB',
+		roomKind: 'Video Channel',
+		shortLabel: 'BBB',
+		icon: 'webcam',
+		description: 'Connect attendees in real time for workshops or panels powered by BigBlueButton.',
+		featureFlag: null
+	},
+	{
+		id: 'jitsi',
+		roomTypeId: 'channel-jitsi',
+		label: 'Jitsi',
+		roomKind: 'Video Channel',
+		shortLabel: 'Jitsi',
+		icon: 'webcam',
+		description: 'Connect attendees through a Jitsi meeting.',
+		featureFlag: 'jitsi'
+	},
+	{
+		id: 'janus',
+		roomTypeId: 'channel-janus',
+		label: 'Janus',
+		roomKind: 'Video Channel',
+		shortLabel: 'Janus',
+		icon: 'webcam',
+		description: 'Connect attendees in real time for workshops or panels powered by Janus.',
+		featureFlag: 'janus'
+	}
+]
+
+export function isVideoProviderEnabled(provider, isFeatureEnabled) {
+	return !provider.featureFlag || Boolean(isFeatureEnabled(provider.featureFlag))
+}
+
+export function isVideoProviderPermitted(provider, hasPermission, isAdminMode = false) {
+	if (hasPermission('room:update')) return true
+	if (provider.roomTypeId === 'channel-jitsi') {
+		return hasPermission('world:rooms.create.jitsi')
+	}
+	return isRoomTypeAvailable(provider.roomTypeId, hasPermission, isAdminMode)
+}
+
+export function getAvailableVideoProviders(hasPermission, isAdminMode, isFeatureEnabled) {
+	return VIDEO_CREATE_PROVIDERS.filter(provider =>
+		isVideoProviderEnabled(provider, isFeatureEnabled) &&
+		isVideoProviderPermitted(provider, hasPermission, isAdminMode)
+	)
+}
+
+export function getVideoProviderByRoomTypeId(roomTypeId) {
+	return VIDEO_CREATE_PROVIDERS.find(provider => provider.roomTypeId === roomTypeId) || null
+}
+
+export function getConfiguredRoomLabel(type) {
+	if (!type) return ''
+	const provider = getVideoProviderByRoomTypeId(type.id)
+	if (provider) return `${provider.roomKind}: ${provider.shortLabel}`
+	if (type.id === 'channel-zoom') return 'Video Channel: Zoom'
+	return type.name
+}
+
+export function getVideoProviderStartingConfig(type) {
+	if (type?.id === 'stage') {
+		return { playback_mode: 'always_on' }
+	}
+	return {}
+}
+
+export function applyVideoProviderToConfig(config, type) {
+	if (!config || !type) return false
+	config.module_config = [{
+		type: type.startingModule,
+		config: getVideoProviderStartingConfig(type)
+	}]
+	return true
+}
+
+export function canManageVideoRooms(hasPermission) {
+	return hasPermission('room:update')
+}

--- a/app/eventyay/webapp/video/src/lib/video-providers.test.js
+++ b/app/eventyay/webapp/video/src/lib/video-providers.test.js
@@ -1,0 +1,109 @@
+/**
+ * Video provider dropdown helpers.
+ * Run: node --test src/lib/video-providers.test.js
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+	VIDEO_CREATE_PROVIDERS,
+	applyVideoProviderToConfig,
+	getAvailableVideoProviders,
+	getConfiguredRoomLabel,
+	isVideoProviderEnabled,
+	isVideoProviderPermitted,
+} from './video-providers.js'
+
+function allow(permissions) {
+	const permitted = new Set(permissions)
+	return (permission) => permitted.has(permission)
+}
+
+function features(enabledFlags) {
+	const flags = new Set(enabledFlags)
+	return (flag) => flags.has(flag)
+}
+
+test('dropdown labels match the organiser create options', () => {
+	assert.deepEqual(
+		VIDEO_CREATE_PROVIDERS.map(provider => provider.label),
+		['Stream (YT, HLS)', 'BBB', 'Jitsi', 'Janus']
+	)
+})
+
+test('disabled feature flags hide Jitsi and Janus', () => {
+	const providers = getAvailableVideoProviders(
+		allow(['room:update']),
+		false,
+		features([])
+	)
+	assert.deepEqual(providers.map(provider => provider.id), ['stream', 'bbb'])
+})
+
+test('enabled Jitsi and Janus flags include those providers', () => {
+	const providers = getAvailableVideoProviders(
+		allow(['room:update']),
+		false,
+		features(['jitsi', 'janus'])
+	)
+	assert.deepEqual(providers.map(provider => provider.id), ['stream', 'bbb', 'jitsi', 'janus'])
+})
+
+test('users without create or update permission see no providers', () => {
+	const providers = getAvailableVideoProviders(
+		allow([]),
+		false,
+		features(['jitsi', 'janus'])
+	)
+	assert.equal(providers.length, 0)
+})
+
+test('stage create permission is enough for Stream', () => {
+	const providers = getAvailableVideoProviders(
+		allow(['world:rooms.create.stage']),
+		false,
+		features([])
+	)
+	assert.deepEqual(providers.map(provider => provider.id), ['stream'])
+})
+
+test('Jitsi does not require admin mode when the organiser can update rooms', () => {
+	assert.equal(
+		isVideoProviderPermitted(
+			VIDEO_CREATE_PROVIDERS.find(provider => provider.id === 'jitsi'),
+			allow(['room:update']),
+			false
+		),
+		true
+	)
+})
+
+test('Jitsi stays hidden when its feature flag is off', () => {
+	assert.equal(
+		isVideoProviderEnabled(
+			VIDEO_CREATE_PROVIDERS.find(provider => provider.id === 'jitsi'),
+			features([])
+		),
+		false
+	)
+})
+
+test('configured room labels include the video provider', () => {
+	assert.equal(getConfiguredRoomLabel({id: 'stage', name: 'Stage'}), 'Stage: Stream')
+	assert.equal(getConfiguredRoomLabel({id: 'channel-bbb', name: 'Video Channel'}), 'Video Channel: BBB')
+	assert.equal(getConfiguredRoomLabel({id: 'channel-jitsi', name: 'Video Channel (Jitsi)'}), 'Video Channel: Jitsi')
+	assert.equal(getConfiguredRoomLabel({id: 'channel-janus', name: 'Video Channel (beta)'}), 'Video Channel: Janus')
+	assert.equal(getConfiguredRoomLabel({id: 'channel-zoom', name: 'Video Channel (Zoom)'}), 'Video Channel: Zoom')
+	assert.equal(getConfiguredRoomLabel({id: 'channel-text', name: 'Text Channel'}), 'Text Channel')
+})
+
+test('applying a provider sets the starting module config', () => {
+	const config = { module_config: [] }
+	assert.equal(
+		applyVideoProviderToConfig(config, {id: 'stage', startingModule: 'livestream.native'}),
+		true
+	)
+	assert.deepEqual(config.module_config, [{
+		type: 'livestream.native',
+		config: { playback_mode: 'always_on' }
+	}])
+})

--- a/app/eventyay/webapp/video/src/views/admin/rooms/RoomListItem.vue
+++ b/app/eventyay/webapp/video/src/views/admin/rooms/RoomListItem.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-router-link.c-room-list-item.table-row(:to="{name: 'admin:rooms:item', params: {roomId: room.id}}", :class="{'mystery': !inferredType}", draggable="false")
+router-link.c-room-list-item.table-row(:to="{name: 'admin:rooms:item', params: {roomId: room.id}}", draggable="false")
 	.handle.mdi.mdi-drag-vertical(:class="{disabled}", v-handle, v-tooltip="disabled ? 'sorting is disabled while searching' : ''")
 	.name(v-html="$emojify(room.name)")
 	.badge-cell
@@ -7,15 +7,25 @@ router-link.c-room-list-item.table-row(:to="{name: 'admin:rooms:item', params: {
 			.room-type-badge.unscheduled-room-badge(v-if="room.is_unscheduled")
 				.mdi.mdi-calendar-remove
 				span Unscheduled
-			.room-type-badge(:class="badgeClass")
+			.room-type-badge(v-if="inferredType", :class="badgeClass")
 				.mdi(:class="badgeIcon")
 				span {{ badgeLabel }}
+			VideoProviderDropdown(
+				v-else,
+				label="Add Video",
+				variant="action",
+				placement="bottom-end",
+				@select="addVideo"
+			)
 </template>
 <script>
 import { ElementMixin, HandleDirective } from 'vue-slicksort'
 import { inferType } from 'lib/room-types'
+import { getConfiguredRoomLabel } from 'lib/video-providers'
+import VideoProviderDropdown from 'components/VideoProviderDropdown'
 
 export default {
+	components: { VideoProviderDropdown },
 	directives: { handle: HandleDirective },
 	mixins: [ElementMixin],
 	props: {
@@ -24,18 +34,26 @@ export default {
 	computed: {
 		inferredType () {
 			// Only treat rooms as configured when they have module_config.
-			// Unconfigured rooms should stay visibly "mystery" in the list.
 			if (!Array.isArray(this.room?.module_config) || this.room.module_config.length === 0) return null
 			return inferType({ module_config: this.room.module_config })
 		},
 		badgeLabel () {
-			return this.inferredType ? this.inferredType.name : 'Unconfigured'
+			return getConfiguredRoomLabel(this.inferredType)
 		},
 		badgeIcon () {
-			return this.inferredType ? `mdi-${this.inferredType.icon}` : 'mdi-help-circle-outline'
+			return `mdi-${this.inferredType.icon}`
 		},
 		badgeClass () {
-			return this.inferredType ? `type-${this.inferredType.id}` : 'type-mystery'
+			return `type-${this.inferredType.id}`
+		}
+	},
+	methods: {
+		addVideo (provider) {
+			this.$router.push({
+				name: 'admin:rooms:item',
+				params: { roomId: this.room.id },
+				query: { provider: provider.roomTypeId }
+			})
 		}
 	}
 }
@@ -45,8 +63,6 @@ export default {
 	display: flex
 	align-items: center
 	color: $clr-primary-text-light
-	&.mystery
-		border-left: 3px solid $clr-orange
 	.handle
 		user-select: none
 		cursor: row-resize
@@ -71,7 +87,7 @@ export default {
 		align-items: center
 		gap: 4px
 		flex: none
-		max-width: 220px
+		max-width: 260px
 		padding: 4px 10px
 		border-radius: 999px
 		font-size: 12px
@@ -88,10 +104,6 @@ export default {
 			overflow: hidden
 			text-overflow: ellipsis
 			display: block
-		&.type-mystery
-			background-color: $clr-orange-100
-			color: $clr-orange-900
-			border-color: $clr-orange-100
 		&.unscheduled-room-badge
 			background-color: $clr-cyan-100
 			color: $clr-cyan-900
@@ -102,6 +114,7 @@ export default {
 			border-color: $clr-blue-50
 		&.type-channel-bbb,
 		&.type-channel-janus,
+		&.type-channel-jitsi,
 		&.type-channel-zoom,
 		&.type-channel-roulette
 			background-color: $clr-blue-grey-200

--- a/app/eventyay/webapp/video/src/views/admin/rooms/index.vue
+++ b/app/eventyay/webapp/video/src/views/admin/rooms/index.vue
@@ -3,7 +3,11 @@
 	.header
 		.actions
 			h2 Rooms
-			bunt-link-button.btn-create(:to="{name: 'admin:rooms:new'}") Create a new room
+			VideoProviderDropdown(
+				label="Create Room",
+				:show-empty-message="true",
+				@select="createRoomWithProvider"
+			)
 		.right-actions
 			.export-actions(v-if="canExportBroadcastConfiguration")
 				a.export-button(:href="exportUrl('xlsx')") Export XLSX
@@ -29,16 +33,16 @@
 		bunt-progress-circular(v-else, size="huge", :page="true")
 </template>
 <script>
-// TODO show inferred type
 import api from 'lib/api'
 import fuzzysearch from 'lib/fuzzysearch'
 import { mapGetters } from 'vuex'
 import { SlickList } from 'vue-slicksort'
+import VideoProviderDropdown from 'components/VideoProviderDropdown'
 import RoomListItem from './RoomListItem'
 
 export default {
 	name: 'AdminRooms',
-	components: { SlickList, RoomListItem },
+	components: { SlickList, RoomListItem, VideoProviderDropdown },
 	data() {
 		return {
 			rooms: null,
@@ -108,6 +112,9 @@ export default {
 				console.error(e)
 			}
 		},
+		createRoomWithProvider(provider) {
+			this.$router.push({name: 'admin:rooms:new', params: {type: provider.roomTypeId}})
+		},
 		async onListSort(newList) {
 			if (this.search) return
 			const previousRooms = [...this.rooms]
@@ -142,6 +149,8 @@ export default {
 				margin-right: 16px
 			.btn-create
 				themed-button-primary()
+			.c-video-provider-dropdown
+				margin-right: 8px
 		.right-actions
 			display: flex
 			align-items: center

--- a/app/eventyay/webapp/video/src/views/admin/rooms/item.vue
+++ b/app/eventyay/webapp/video/src/views/admin/rooms/item.vue
@@ -10,12 +10,12 @@
 				bunt-icon-button(@click="$router.push({name: 'admin:rooms:index'})") arrow_left
 				h1(v-html="$emojify(config.name)")
 			.mystery-room
-				p Room not instantiated.
-				bunt-button(@click="showRoomEditPrompt = true") Initiate room
+				p This room does not have a video option yet.
+				VideoProviderDropdown(label="Add Video", variant="action", @select="addVideoProvider")
 		template(v-else)
 			.ui-page-header
 				bunt-icon-button(@click="$router.push({name: 'admin:rooms:index'})") arrow_left
-				h1 {{ inferredType ? inferredType.name : 'Mystery Room' }} :
+				h1 {{ roomTypeLabel }} :
 					span.room-name(v-html="$emojify(config.name)")
 				.actions
 					bunt-button(v-if="hasPermission('room:update')", @click="showRoomEditPrompt = true") Edit
@@ -33,12 +33,19 @@
 import { mapGetters } from 'vuex'
 import api from 'lib/api'
 import RoomEditPrompt from 'components/RoomEditPrompt'
-import { inferType } from 'lib/room-types'
+import VideoProviderDropdown from 'components/VideoProviderDropdown'
+import { getRoomTypeById, inferType } from 'lib/room-types'
+import {
+	applyVideoProviderToConfig,
+	getAvailableVideoProviders,
+	getConfiguredRoomLabel,
+} from 'lib/video-providers'
+import features from 'features'
 import EditForm from './EditForm'
 
 export default {
 	name: 'AdminRoom',
-	components: { EditForm, RoomEditPrompt },
+	components: { EditForm, RoomEditPrompt, VideoProviderDropdown },
 	props: {
 		roomId: String
 	},
@@ -52,9 +59,20 @@ export default {
 		}
 	},
 	computed: {
-		...mapGetters(['hasPermission']),
+		...mapGetters(['hasPermission', 'isAdminMode']),
 		inferredType() {
+			if (!this.config) return null
 			return inferType(this.config)
+		},
+		roomTypeLabel() {
+			return getConfiguredRoomLabel(this.inferredType)
+		},
+		availableProviders() {
+			return getAvailableVideoProviders(
+				this.hasPermission,
+				this.isAdminMode,
+				(flag) => features.enabled(flag)
+			)
 		}
 	},
 	async created() {
@@ -83,11 +101,43 @@ export default {
 				this.error = null
 				this.errorCode = null
 				this.config = await api.call('room.config.get', {room: this.roomId})
+				await this.applyProviderFromQuery()
 			} catch (error) {
 				this.error = error
 				this.errorCode = error?.code || error?.message || String(error)
 				console.error(error)
 			}
+		},
+		async applyProvider(roomTypeId) {
+			if (this.inferredType) return
+			if (!this.availableProviders.some(provider => provider.roomTypeId === roomTypeId)) return
+			const type = getRoomTypeById(roomTypeId)
+			if (!type) return
+			const previousModuleConfig = this.config.module_config
+			applyVideoProviderToConfig(this.config, type)
+			try {
+				const updated = await api.call('room.config.patch', {
+					room: this.config.id,
+					module_config: this.config.module_config
+				})
+				Object.assign(this.config, updated)
+			} catch (error) {
+				this.config.module_config = previousModuleConfig
+				console.error('Failed to apply video provider: %o', error)
+			}
+		},
+		async applyProviderFromQuery() {
+			const roomTypeId = this.$route.query.provider
+			if (!roomTypeId) return
+			await this.applyProvider(roomTypeId)
+			if (this.$route.query.provider) {
+				const query = { ...this.$route.query }
+				delete query.provider
+				this.$router.replace({ query })
+			}
+		},
+		addVideoProvider(provider) {
+			return this.applyProvider(provider.roomTypeId)
 		},
 		closeRoomEditPrompt() {
 			this.showRoomEditPrompt = false

--- a/app/eventyay/webapp/video/src/views/admin/rooms/new.vue
+++ b/app/eventyay/webapp/video/src/views/admin/rooms/new.vue
@@ -1,42 +1,43 @@
 <template lang="pug">
 .c-admin-rooms-new
 	.ui-page-header
-		bunt-icon-button(@click="type ? $router.replace({name: 'admin:rooms:new'}) : $router.replace({name: 'admin:rooms:index'})") arrow_left
+		bunt-icon-button(@click="$router.replace({name: 'admin:rooms:index'})") arrow_left
 		h1 New room
-			template(v-if="chosenType")  : {{ chosenType.name }}
-	.choose-type(v-if="!type", v-scrollbar.y="")
-		h2 Choose a room type
-		.types
-			router-link.type(v-for="type of ROOM_TYPES", :to="{name: 'admin:rooms:new', params: {type: type.id}}")
-				.icon.mdi(:class="[`mdi-${type.icon}`]")
-				.text
-					.name {{ type.name }}
-					.description {{ type.description }}
-	edit-form(v-else, :config="config", :creating="true")
+			template(v-if="chosenProvider")  : {{ chosenProvider.label }}
+	edit-form(v-if="config", :config="config", :creating="true")
 </template>
 <script>
 import { mapGetters } from 'vuex'
-import ROOM_TYPES from 'lib/room-types'
-import { filterRoomTypesByPermission } from 'lib/room-type-permissions'
-import { PLAYBACK_MODE_ALWAYS_ON } from 'lib/stage-streams'
+import features from 'features'
+import { getRoomTypeById } from 'lib/room-types'
+import {
+	applyVideoProviderToConfig,
+	getAvailableVideoProviders,
+} from 'lib/video-providers'
 import EditForm from './EditForm'
 
 export default {
 	components: { EditForm },
 	data() {
 		return {
-			allRoomTypes: ROOM_TYPES,
 			type: null,
 			config: null
 		}
 	},
 	computed: {
 		...mapGetters(['hasPermission', 'isAdminMode']),
-		ROOM_TYPES() {
-			return filterRoomTypesByPermission(this.allRoomTypes, this.hasPermission, this.isAdminMode)
+		availableProviders() {
+			return getAvailableVideoProviders(
+				this.hasPermission,
+				this.isAdminMode,
+				(flag) => features.enabled(flag)
+			)
+		},
+		chosenProvider() {
+			return this.availableProviders.find(provider => provider.roomTypeId === this.type) || null
 		},
 		chosenType() {
-			return this.ROOM_TYPES.find(t => t.id === this.type)
+			return this.chosenProvider ? getRoomTypeById(this.chosenProvider.roomTypeId) : null
 		},
 	},
 	watch: {
@@ -46,17 +47,10 @@ export default {
 		this.updateType()
 	},
 	methods: {
-		getStartingModuleConfig(type) {
-			if (type.id === 'stage') {
-				return { playback_mode: PLAYBACK_MODE_ALWAYS_ON }
-			}
-			return {}
-		},
 		updateType() {
 			this.type = this.$route.params.type
-			if (!this.type) return
-			if (!this.chosenType) {
-				this.$router.replace({name: 'admin:rooms:new'})
+			if (!this.type || !this.chosenType) {
+				this.$router.replace({name: 'admin:rooms:index'})
 				return
 			}
 			this.config = {
@@ -65,8 +59,9 @@ export default {
 				sorting_priority: '',
 				pretalx_id: '',
 				force_join: false,
-				module_config: [{type: this.chosenType.startingModule, config: this.getStartingModuleConfig(this.chosenType)}],
+				module_config: [],
 			}
+			applyVideoProviderToConfig(this.config, this.chosenType)
 		}
 	}
 }
@@ -87,45 +82,4 @@ export default {
 	h1
 		font-size: 24px
 		font-weight: 500
-	.choose-type
-		display: flex
-		flex-direction: column
-		height: 89vh
-		> *
-			margin: 16px
-		h2
-			margin: 16px 16px 0px
-	.types
-		display: flex
-		flex-direction: column
-		border: border-separator()
-		border-radius: 4px
-		max-width: 480px
-		.type
-			display: flex
-			min-height: 52px
-			flex: none
-			cursor: pointer
-			padding: 0 16px 0 8px
-			box-sizing: border-box
-			font-size: 16px
-			align-items: center
-			color: $clr-primary-text-light
-			&:not(:last-child)
-				border-bottom: border-separator()
-			&:hover
-				background-color: $clr-grey-50
-			.icon
-				font-size: 30px
-				line-height: 52px
-				margin: 0 8px 0 0
-			.text
-				display: flex
-				flex-direction: column
-				padding: 5px 0
-			.name
-				line-height: 24px
-			.description
-				color: $clr-secondary-text-light
-				font-size: 13px
 </style>

--- a/doc/developer-guide/video-frontend.rst
+++ b/doc/developer-guide/video-frontend.rst
@@ -26,9 +26,13 @@ The video frontend is a full-featured virtual event platform built with Vue 3, p
 - **Networking**: Speed networking (roulette) and direct messaging
 - **Recordings**: On-demand video playback
 
-New rooms can be created as **Stage**, **Video Channel**, or **Text Channel**.
-Exhibition halls, poster halls, static pages, iframe pages, and user lists have been removed
-from the video room catalog. Meetup embed URLs use a stage iframe player instead.
+New rooms are created from the organiser rooms page with a **Create Room** dropdown.
+The available video options are **Stream (YT, HLS)**, **BBB**, **Jitsi**, and **Janus**,
+filtered by platform feature flags and the organiser's permissions.
+Unconfigured rooms use **Add Video** with the same provider list instead of an
+Unconfigured badge. Exhibition halls, poster halls, static pages, iframe pages,
+and user lists have been removed from the video room catalog. Meetup embed URLs
+use a stage iframe player instead.
 
 **Location**: ``app/eventyay/webapp/video/``
 


### PR DESCRIPTION
## Summary
- Replaces **Create a new room** / **Choose a room type** with a **Create Room** dropdown of platform-enabled video options: Stream (YT, HLS), BBB, Jitsi, and Janus.
- Unconfigured rooms show an **Add Video** action (same dropdown) instead of an Unconfigured badge; selecting a provider configures that existing room.
- Configured rooms show compact labels such as **Stage: Stream** and **Video Channel: BBB**. Direct `/event/rooms/new` URLs redirect to the rooms list.

Fixes #5100

## Test plan
- [ ] On the organiser rooms page, **Create Room** opens a dropdown attached to the button and is keyboard accessible (Enter/Space/Arrow keys/Escape).
- [ ] Dropdown options match enabled platform flags: Jitsi/Janus hide when their flags are off; Stream and BBB remain when the organiser can create/configure rooms.
- [ ] If no providers are available, **Create Room** is disabled and the empty-state message is shown.
- [ ] Choosing a provider opens the create form with that video option already selected (no Choose a room type page).
- [ ] `/event/rooms/new` and unknown type URLs redirect to the rooms list.
- [ ] Unconfigured rooms show **Add Video**; choosing a provider applies it to that room and opens the edit form.
- [ ] Configured rooms show labels like `Stage: Stream`, `Video Channel: BBB`, `Video Channel: Jitsi`, `Video Channel: Janus`.
- [ ] Search, export, reorder, and existing room edit still work.
- [ ] `node --test app/eventyay/webapp/video/src/lib/video-providers.test.js` passes.

## Summary by Sourcery

Replace room-type selection with a provider-focused video room creation and configuration flow.

New Features:
- Add a Create Room dropdown and per-room Add Video action for selecting supported video providers.
- Display configured rooms with provider-specific labels and allow providers to be applied to existing unconfigured rooms.

Bug Fixes:
- Redirect invalid or direct room-creation URLs to the rooms list.

Enhancements:
- Centralize video-provider availability, permissions, feature flags, labels, and initial configuration handling.
- Make provider selection keyboard accessible and show an empty state when no video options are available.

Documentation:
- Update the video frontend developer guide for the revised room and video-provider flow.

Tests:
- Add coverage for provider availability, feature flags, permissions, labels, and initial configuration.