### PR TITLE
Remove Start page prefix from the public homepage title

### DIFF
--- a/app/eventyay/presale/templates/pretixpresale/startpage_base.html
+++ b/app/eventyay/presale/templates/pretixpresale/startpage_base.html
@@ -10,7 +10,7 @@
 <html lang="{{ html_locale }}"{% if rtl %} dir="rtl" class="rtl"{% endif %}>
     <head>
         <meta charset="utf-8">
-        <title>{% block page_title %}{% trans 'Start page' %}{% endblock %} :: {{ site_name }}</title>
+        <title>{{ site_name }}</title>
         {% block meta_tags %}
         <meta name="title" content="{% trans 'Start page' %} {{ site_name }}">
         <meta name="description" content="{% trans 'Browse live events on' %} {{ site_name }}">


### PR DESCRIPTION
## Summary
- The public start page browser title is now just the site name instead of `Start page :: <site name>`.

## Test plan
- [ ] Open the public start page and confirm the browser tab title is the site name only.
- [ ] Child pages that override `page_title` still render their own titles where those templates set them.

## Summary by Sourcery

Enhancements:
- Simplify the public start page browser title to display only the site name while preserving existing page metadata and child-page title behavior.