### PR TITLE
Disable Gunicorn control socket in production

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   web:
     image: eventyay/eventyay-next:${TAG}
     container_name: eventyay-next-web
-    command: gunicorn eventyay.config.wsgi:application --bind 0.0.0.0:8000 --worker-class gthread --workers 2 --threads 4 --timeout 60 --graceful-timeout 30 --max-requests 1000 --max-requests-jitter 100
+    command: gunicorn eventyay.config.wsgi:application --bind 0.0.0.0:8000 --worker-class gthread --workers 2 --threads 4 --timeout 60 --graceful-timeout 30 --max-requests 1000 --max-requests-jitter 100 --no-control-socket
     volumes:
       - ${DATA_DIR:-./data}/static:/home/app/web/eventyay/static.dist
       - ${DATA_DIR:-./data}/data:/home/app/web/eventyay/data


### PR DESCRIPTION
## Summary
- Adds `--no-control-socket` to the production Gunicorn command so it no longer tries to create `$HOME/.gunicorn`.
- Fixes `Control server error: [Errno 13] Permission denied: '/home/app/.gunicorn'` on the web container. 

## Test plan
- [ ] Deploy or recreate `eventyay-next-web` with the updated compose command (`docker compose up -d web`)
- [ ] Confirm web logs no longer show `Permission denied: '/home/app/.gunicorn'`
- [ ] Confirm the site still serves HTTP on port 8000 (tickets, admin, API)

## Summary by Sourcery

Disable Gunicorn's production control socket to prevent permission errors when starting the web container.

Bug Fixes:
- Prevent production Gunicorn from attempting to create its control socket directory, eliminating permission errors in the web container.

Deployment:
- Update the production web service command to disable Gunicorn's control socket while preserving the existing HTTP worker configuration.