### PR TITLE
fix: keep schedule API up when Redis blips and quiet host-header logs

### DIFF
--- a/app/eventyay/base/middleware.py
+++ b/app/eventyay/base/middleware.py
@@ -482,7 +482,7 @@ def request_prefers_json_api(request):
 
 
 def is_load_shed_exempt(path):
-    if path.startswith('/healthcheck'):
+    if path.startswith('/healthcheck') or '/video/assets/' in path:
         return True
     return bool(CHECKIN_EXEMPT_RE.search(path))
 

--- a/app/eventyay/base/middleware.py
+++ b/app/eventyay/base/middleware.py
@@ -343,6 +343,7 @@ class SecurityMiddleware(MiddlewareMixin):
             + img_src,
             'font-src': [
                 '{static}',
+                'data:',
                 'https://fonts.gstatic.com',  # fix Google Fonts
                 *vite_http,
             ],

--- a/app/eventyay/base/models/event.py
+++ b/app/eventyay/base/models/event.py
@@ -39,6 +39,7 @@ from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
 from django_scopes import ScopedManager, scope, scopes_disabled
 from i18nfield.fields import I18nCharField, I18nTextField
+from redis.exceptions import RedisError
 from rules.contrib.models import RulesModelBase, RulesModelMixin
 
 from eventyay.base.models.base import LoggedModel
@@ -2347,17 +2348,23 @@ class Event(
     @cached_property
     def locales(self) -> list[str]:
         """Is a list of active event locales."""
-        if hasattr(self, 'settings') and 'locales' in self.settings._cache():
-            if locales := self.settings.get('locales', as_type=list):
-                return locales
+        try:
+            if hasattr(self, 'settings') and 'locales' in self.settings._cache():
+                if locales := self.settings.get('locales', as_type=list):
+                    return locales
+        except RedisError:
+            logger.warning('Event settings cache unavailable while reading locales for %s', self.slug)
         return [code for code in self.locale_array.split(',') if code]
 
     @cached_property
     def content_locales(self) -> list[str]:
         """Is a list of active content locales."""
-        if hasattr(self, 'settings') and 'content_locales' in self.settings._cache():
-            if locales := self.settings.get('content_locales', as_type=list):
-                return locales
+        try:
+            if hasattr(self, 'settings') and 'content_locales' in self.settings._cache():
+                if locales := self.settings.get('content_locales', as_type=list):
+                    return locales
+        except RedisError:
+            logger.warning('Event settings cache unavailable while reading content locales for %s', self.slug)
         fallback = [code for code in self.content_locale_array.split(',') if code]
         return fallback or self.locales
 

--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -1272,6 +1272,9 @@ LOGGING = {
         'handlers': [_adaptive_console_handler],
     },
     'formatters': _LOGGING_FORMATTERS,
+    'filters': {
+        'one_line_warning': {'()': 'eventyay.helpers.security.OneLineWarningFilter'},
+    },
     'handlers': _LOGGING_HANDLERS,
     'loggers': {
         'django.db.backends': {
@@ -1293,6 +1296,11 @@ LOGGING = {
         'eventyay': {
             'handlers': [_adaptive_console_handler],
             'level': 'DEBUG' if DEBUG else 'INFO',
+            'propagate': False,
+        },
+        'django.security.DisallowedHost': {
+            'handlers': [_adaptive_console_handler],
+            'filters': ['one_line_warning'],
             'propagate': False,
         },
     },

--- a/app/eventyay/helpers/security.py
+++ b/app/eventyay/helpers/security.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 import time
 
 from django.conf import settings
@@ -49,3 +50,13 @@ def assert_session_valid(request: HttpRequest) -> bool:
 
     request.session[KEY_LAST_LOGIN_CHECK] = int(time.time())
     return True
+
+
+class OneLineWarningFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.exc_info = None
+        record.exc_text = None
+        record.levelno = logging.WARNING
+        record.levelname = 'WARNING'
+        return True
+

--- a/app/tests/stable/test_load_shedding.py
+++ b/app/tests/stable/test_load_shedding.py
@@ -105,6 +105,7 @@ def test_load_shedding_keeps_api_overload_json(monkeypatch):
     'path',
     [
         '/healthcheck/',
+        '/dsa/k39j9g/video/assets/main.css',
         '/api/v1/organizers/wm/checkin/redeem/',
         '/api/v1/organizers/wm/events/wm/checkinlists/',
         '/api/v1/organizers/wm/events/wm/checkinlists/1/positions/',

--- a/app/tests/talk/event/test_event_model.py
+++ b/app/tests/talk/event/test_event_model.py
@@ -41,6 +41,23 @@ def test_locales(event, locale_array, count):
 
 
 @pytest.mark.django_db
+def test_locales_fall_back_when_redis_cache_times_out(event, monkeypatch):
+    from redis.exceptions import TimeoutError as RedisTimeoutError
+
+    event.locale_array = 'en,de'
+    event.save()
+    event.settings.set('locales', ['fr'])
+    event.__dict__.pop('locales', None)
+
+    monkeypatch.setattr(
+        event.settings,
+        '_cache',
+        lambda: (_ for _ in ()).throw(RedisTimeoutError('Timeout reading from socket')),
+    )
+    assert event.locales == ['en', 'de']
+
+
+@pytest.mark.django_db
 def test_initial_data(event):
     with scope(event=event):
         assert event.cfp

--- a/app/tests/tickets/base/test_middleware.py
+++ b/app/tests/tickets/base/test_middleware.py
@@ -149,3 +149,10 @@ class SecurityMiddlewareTest(TestCase):
 
         img_src = get_csp_directive_values(response['Content-Security-Policy'], 'img-src')
         assert 'https://cdn.example.com' in img_src
+
+    @override_settings(SITE_URL='https://example.com')
+    def test_security_middleware_allows_data_fonts(self):
+        response = self.build_response('/', view_name='presale:index')
+
+        font_src = get_csp_directive_values(response['Content-Security-Policy'], 'font-src')
+        assert 'data:' in font_src


### PR DESCRIPTION
## Summary
- Fall back to the event `locale_array` when Redis times out while reading settings, so orga schedule API requests no longer 500.
- Allow `data:` in CSP `font-src` to stop schedule-rooms font violations.
- Log unknown `Host` headers as a one-line WARNING (no traceback) so scanner probes stay visible without flooding error logs.

## Test plan
- [x] Unit tests added for locale Redis fallback and CSP `font-src`
- [x] Verified `OneLineWarningFilter` loads from Django logging config and emits one WARNING line with no traceback
- [ ] Confirm orga schedule talk API still works when Redis is healthy
- [ ] Confirm orga schedule talk API returns 200 (not 500) if Redis briefly times out
- [ ] Confirm a request with a forged Host header is still 400 and logs one WARNING line
- [ ] Confirm schedule rooms page no longer reports `font-src` / `data` CSP violations

## Summary by Sourcery

Keep schedule-related requests resilient during Redis outages and reduce noise from invalid Host-header probes.

Bug Fixes:
- Keep event locale resolution available when Redis settings reads fail by falling back to the event’s stored locale configuration.
- Allow video asset requests to bypass load shedding so schedule resources remain available during overload.
- Permit data-backed fonts through the Content Security Policy.
- Reduce unknown Host-header security logs to a single warning without traceback.

Tests:
- Add coverage for Redis locale fallback, data-font CSP support, and video asset load-shedding exemptions.