### PR TITLE
fix(schedule): Fix Invalid URL error in SpeakersList pagination

### DIFF
--- a/app/eventyay/webapp/schedule/src/components/SpeakersList.vue
+++ b/app/eventyay/webapp/schedule/src/components/SpeakersList.vue
@@ -598,8 +598,10 @@ export default {
 				if (!res.ok) throw new Error(`HTTP error! status: ${res.status}`)
 				const data = await res.json()
 				this.speakersFromApi = append ? this.speakersFromApi.concat(data.results) : data.results
+				const base = (this.eventUrl || '').replace(/\/?$/, '/')
+				const baseUrl = new URL(base || window.location.href, window.location.origin)
 				this.nextPageUrl = data.next
-					? new URL(data.next, this.eventUrl || window.location.origin).toString()
+					? new URL(data.next, baseUrl).toString()
 					: null
 			} catch (e) {
 				if (e.name !== 'AbortError') {


### PR DESCRIPTION
Fixes a TypeError in SpeakersList.vue where passing a relative path as the base URL to the URL constructor caused an error when loading more speakers. Built cleanly on top of upstream/dev.

## Summary by Sourcery

Bug Fixes:
- Fix speaker pagination when the API returns relative next-page URLs by resolving them against a valid absolute base URL.