### PR TITLE
feat(common): group hubspot and social media accounts under settings in organizer sidebar

### DIFF
--- a/app/eventyay/eventyay_common/navigation.py
+++ b/app/eventyay/eventyay_common/navigation.py
@@ -125,6 +125,19 @@ def get_event_navigation(request: HttpRequest, event: Event) -> List[MenuItem]:
 
     return nav
 
+
+def _is_hubspot_nav_item(item: dict) -> bool:
+    url = item.get('url', '')
+    label = str(item.get('label', '')).lower()
+    return 'hubspot' in url or label == 'hubspot'
+
+
+def _is_social_media_nav_item(item: dict) -> bool:
+    url = item.get('url', '')
+    label = str(item.get('label', '')).lower()
+    return 'socialmedia' in url or 'social_media' in url or 'social-media' in url or label == 'social media accounts'
+
+
 def get_organizer_navigation(request: HttpRequest) -> List[MenuItem]:
     url = request.resolver_match
     if not url:
@@ -252,20 +265,48 @@ def get_organizer_navigation(request: HttpRequest) -> List[MenuItem]:
         }
     )
 
-
-    merge_in(
-        nav,
-        sorted(
-            sum(
-                (
-                    list(a[1])
-                    for a in nav_organizer.send(request.organizer, request=request, organizer=request.organizer)
-                ),
-                [],
-            ),
-            key=lambda r: (1 if r.get('parent') else 0, r['label']),
-        ),
+    plugin_responses = nav_organizer.send(
+        request.organizer,
+        request=request,
+        organizer=request.organizer,
     )
+    plugin_nav_items = []
+    for receiver, response in plugin_responses:
+        if response:
+            plugin_nav_items.extend(response)
+
+    hubspot_item = None
+    social_media_item = None
+    other_plugin_items = []
+
+    for item in plugin_nav_items:
+        if _is_hubspot_nav_item(item):
+            hubspot_item = item
+        elif _is_social_media_nav_item(item):
+            social_media_item = item
+        else:
+            other_plugin_items.append(item)
+
+    settings_url = reverse(
+        'eventyay_common:organizer.edit',
+        kwargs={'organizer': request.organizer.slug},
+    )
+    settings_item = next((n for n in nav if n.get('url') == settings_url), None)
+
+    if settings_item is not None:
+        if hubspot_item:
+            settings_item['children'].append(hubspot_item)
+        if social_media_item:
+            settings_item['children'].append(social_media_item)
+
+    # Sort remaining navigation items, prioritizing non-parent items and alphabetically
+    sorted_plugin_items = sorted(
+        other_plugin_items,
+        key=lambda r: (1 if r.get('parent') else 0, r['label']),
+    )
+
+    # Merge plugin items into default navigation
+    merge_in(nav, sorted_plugin_items)
     return nav
 
 

--- a/app/tests/eventyay_common/test_organizer_navigation.py
+++ b/app/tests/eventyay_common/test_organizer_navigation.py
@@ -1,0 +1,224 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.urls import resolve, reverse
+
+from eventyay.control.signals import nav_organizer
+from eventyay.eventyay_common.navigation import get_organizer_navigation
+
+
+def test_organizer_navigation_groups_hubspot_and_social_media_under_settings(rf):
+    organizer = SimpleNamespace(slug='test-orga')
+    path = reverse('eventyay_common:organizer.events', kwargs={'organizer': organizer.slug})
+    request = rf.get(path)
+    request.organizer = organizer
+    request.orgapermset = {'can_change_organizer_settings', 'can_change_teams'}
+    request.resolver_match = resolve(path)
+
+    mock_hubspot_item = {
+        'label': 'HubSpot',
+        'url': f'/common/organizer/{organizer.slug}/hubspot/',
+        'active': False,
+        'icon': 'bar-chart',
+    }
+    mock_social_media_item = {
+        'label': 'Social Media Accounts',
+        'url': f'/control/organizer/{organizer.slug}/socialmedia/',
+        'active': False,
+        'icon': 'share-alt',
+    }
+
+    def mock_nav_organizer_send(sender, **kwargs):
+        return [
+            ('hubspot', [mock_hubspot_item]),
+            ('socialmedia', [mock_social_media_item]),
+        ]
+
+    with patch.object(nav_organizer, 'send', side_effect=mock_nav_organizer_send):
+        nav = get_organizer_navigation(request)
+
+    # 1. Verify top-level items do NOT contain HubSpot or Social Media Accounts
+    top_level_labels = [str(item['label']) for item in nav]
+    assert 'HubSpot' not in top_level_labels
+    assert 'Social Media Accounts' not in top_level_labels
+
+    # 2. Verify Settings menu exists and contains children in the exact required order
+    settings_item = next((item for item in nav if str(item['label']) == 'Settings'), None)
+    assert settings_item is not None
+    assert 'children' in settings_item
+
+    child_labels = [str(child['label']) for child in settings_item['children']]
+    assert child_labels == ['General', 'Billing settings', 'HubSpot', 'Social Media Accounts']
+
+    # 3. Verify URLs of children
+    assert settings_item['children'][0]['url'] == reverse(
+        'eventyay_common:organizer.edit', kwargs={'organizer': organizer.slug}
+    )
+    assert settings_item['children'][1]['url'] == reverse(
+        'eventyay_common:organizer.billing', kwargs={'organizer': organizer.slug}
+    )
+    assert settings_item['children'][2]['url'] == f'/common/organizer/{organizer.slug}/hubspot/'
+    assert settings_item['children'][3]['url'] == f'/control/organizer/{organizer.slug}/socialmedia/'
+
+
+def test_organizer_navigation_when_only_hubspot_available(rf):
+    organizer = SimpleNamespace(slug='test-orga')
+    path = reverse('eventyay_common:organizer.events', kwargs={'organizer': organizer.slug})
+    request = rf.get(path)
+    request.organizer = organizer
+    request.orgapermset = {'can_change_organizer_settings'}
+    request.resolver_match = resolve(path)
+
+    mock_hubspot_item = {
+        'label': 'HubSpot',
+        'url': f'/common/organizer/{organizer.slug}/hubspot/',
+        'active': False,
+        'icon': 'bar-chart',
+    }
+
+    def mock_nav_organizer_send(sender, **kwargs):
+        return [
+            ('hubspot', [mock_hubspot_item]),
+        ]
+
+    with patch.object(nav_organizer, 'send', side_effect=mock_nav_organizer_send):
+        nav = get_organizer_navigation(request)
+
+    settings_item = next((item for item in nav if str(item['label']) == 'Settings'), None)
+    assert settings_item is not None
+    child_labels = [str(child['label']) for child in settings_item['children']]
+    assert child_labels == ['General', 'Billing settings', 'HubSpot']
+
+
+def test_organizer_navigation_when_only_social_media_available(rf):
+    organizer = SimpleNamespace(slug='test-orga')
+    path = reverse('eventyay_common:organizer.events', kwargs={'organizer': organizer.slug})
+    request = rf.get(path)
+    request.organizer = organizer
+    request.orgapermset = {'can_change_organizer_settings'}
+    request.resolver_match = resolve(path)
+
+    mock_social_media_item = {
+        'label': 'Social Media Accounts',
+        'url': f'/control/organizer/{organizer.slug}/socialmedia/',
+        'active': False,
+        'icon': 'share-alt',
+    }
+
+    def mock_nav_organizer_send(sender, **kwargs):
+        return [
+            ('socialmedia', [mock_social_media_item]),
+        ]
+
+    with patch.object(nav_organizer, 'send', side_effect=mock_nav_organizer_send):
+        nav = get_organizer_navigation(request)
+
+    settings_item = next((item for item in nav if str(item['label']) == 'Settings'), None)
+    assert settings_item is not None
+    child_labels = [str(child['label']) for child in settings_item['children']]
+    assert child_labels == ['General', 'Billing settings', 'Social Media Accounts']
+
+
+def test_organizer_navigation_active_state_for_settings_children(rf):
+    organizer = SimpleNamespace(slug='test-orga')
+    path = reverse('eventyay_common:organizer.edit', kwargs={'organizer': organizer.slug})
+    request = rf.get(path)
+    request.organizer = organizer
+    request.orgapermset = {'can_change_organizer_settings'}
+    request.resolver_match = resolve(path)
+
+    mock_hubspot_item = {
+        'label': 'HubSpot',
+        'url': f'/common/organizer/{organizer.slug}/hubspot/',
+        'active': True,
+        'icon': 'bar-chart',
+    }
+    mock_social_media_item = {
+        'label': 'Social Media Accounts',
+        'url': f'/control/organizer/{organizer.slug}/socialmedia/',
+        'active': False,
+        'icon': 'share-alt',
+    }
+
+    def mock_nav_organizer_send(sender, **kwargs):
+        return [
+            ('hubspot', [mock_hubspot_item]),
+            ('socialmedia', [mock_social_media_item]),
+        ]
+
+    with patch.object(nav_organizer, 'send', side_effect=mock_nav_organizer_send):
+        nav = get_organizer_navigation(request)
+
+    settings_item = next((item for item in nav if str(item['label']) == 'Settings'), None)
+    assert settings_item is not None
+
+    hubspot_child = next((c for c in settings_item['children'] if str(c['label']) == 'HubSpot'), None)
+    assert hubspot_child is not None
+    assert hubspot_child['active'] is True
+
+    sm_child = next((c for c in settings_item['children'] if str(c['label']) == 'Social Media Accounts'), None)
+    assert sm_child is not None
+    assert sm_child['active'] is False
+
+
+def test_organizer_navigation_without_settings_permission(rf):
+    organizer = SimpleNamespace(slug='test-orga')
+    path = reverse('eventyay_common:organizer.events', kwargs={'organizer': organizer.slug})
+    request = rf.get(path)
+    request.organizer = organizer
+    request.orgapermset = {'can_change_teams'}
+    request.resolver_match = resolve(path)
+
+    mock_hubspot_item = {
+        'label': 'HubSpot',
+        'url': f'/common/organizer/{organizer.slug}/hubspot/',
+        'active': False,
+        'icon': 'bar-chart',
+    }
+    mock_social_media_item = {
+        'label': 'Social Media Accounts',
+        'url': f'/control/organizer/{organizer.slug}/socialmedia/',
+        'active': False,
+        'icon': 'share-alt',
+    }
+
+    def mock_nav_organizer_send(sender, **kwargs):
+        return [
+            ('hubspot', [mock_hubspot_item]),
+            ('socialmedia', [mock_social_media_item]),
+        ]
+
+    with patch.object(nav_organizer, 'send', side_effect=mock_nav_organizer_send):
+        nav = get_organizer_navigation(request)
+
+    top_level_labels = [str(item['label']) for item in nav]
+    assert 'Settings' not in top_level_labels
+    assert 'HubSpot' not in top_level_labels
+    assert 'Social Media Accounts' not in top_level_labels
+
+
+def test_organizer_navigation_other_plugins_preserved(rf):
+    organizer = SimpleNamespace(slug='test-orga')
+    path = reverse('eventyay_common:organizer.events', kwargs={'organizer': organizer.slug})
+    request = rf.get(path)
+    request.organizer = organizer
+    request.orgapermset = {'can_change_organizer_settings'}
+    request.resolver_match = resolve(path)
+
+    mock_other_plugin_item = {
+        'label': 'Custom Plugin',
+        'url': f'/common/organizer/{organizer.slug}/custom/',
+        'active': False,
+        'icon': 'plug',
+    }
+
+    def mock_nav_organizer_send(sender, **kwargs):
+        return [
+            ('custom_plugin', [mock_other_plugin_item]),
+        ]
+
+    with patch.object(nav_organizer, 'send', side_effect=mock_nav_organizer_send):
+        nav = get_organizer_navigation(request)
+
+    top_level_labels = [str(item['label']) for item in nav]
+    assert 'Custom Plugin' in top_level_labels


### PR DESCRIPTION
https://github.com/user-attachments/assets/d54237b3-54e8-4147-b2f2-d64db78d927e

Closes #5168 

### Summary
In the organizer dashboard sidebar, **HubSpot** and **Social Media Accounts** were previously shown as standalone top-level menu items. Since these are organizer-level configuration options, this pull request groups both items under the **Settings** submenu below **Billing settings** and removes them from the top-level navigation.

### Changes Made
- **Organizer Navigation (`eventyay_common/navigation.py`)**:
  - Updated `get_organizer_navigation` to route `HubSpot` and `Social Media Accounts` plugin items returned from `nav_organizer` signal into the `Settings` submenu's `children` list.
  - Placed them below `Billing settings` in the expected order:
    1. `General`
    2. `Billing settings`
    3. `HubSpot` (if plugin available & permitted)
    4. `Social Media Accounts` (if plugin available & permitted)
  - Prevented both items from appearing as standalone top-level sidebar entries.
  - Maintained sidebar active state highlighting for both submenu items and parent expansion.
- **Unit Tests (`tests/eventyay_common/test_organizer_navigation.py`)**:
  - Added comprehensive unit tests validating:
    - Grouping and correct ordering under `Settings`.
    - Absence of standalone top-level entries.
    - Active state highlighting for submenu items.
    - Feature availability and plugin fallback when only one or neither is present.
    - Permission checks (hiding `Settings` and submenus for unauthorized users).
    - Preservation of other non-settings plugin navigation items.

### Checklist
- [x] Preserves existing routes, URLs, and permissions.
- [x] Includes unit tests covering all acceptance criteria.
- [x] Passes Ruff linter and formatting checks.

## Summary by Sourcery

Organize organizer-level HubSpot and social media configuration links within the Settings navigation.

New Features:
- Group HubSpot and Social Media Accounts organizer navigation entries under the Settings submenu.

Bug Fixes:
- Prevent HubSpot and Social Media Accounts from appearing as standalone top-level organizer navigation items while preserving permission and availability behavior.

Enhancements:
- Preserve other plugin navigation entries and maintain active-state behavior for grouped settings items.

Tests:
- Add coverage for grouping order, optional plugin availability, permissions, active states, and preservation of other plugin entries.