### PR TITLE
fix(video): stop force-muting YouTube room streams on autoplay

### DIFF
--- a/app/eventyay/webapp/video/src/components/CreateStagePrompt.vue
+++ b/app/eventyay/webapp/video/src/components/CreateStagePrompt.vue
@@ -55,7 +55,7 @@ export default {
 			streamSource: 'hls',
 			url: '',
 			youtubeId: '',
-			startMuted: true,
+			startMuted: false,
 			description: '',
 			loading: false,
 			error: null,

--- a/app/eventyay/webapp/video/src/components/MediaSource.vue
+++ b/app/eventyay/webapp/video/src/components/MediaSource.vue
@@ -319,9 +319,10 @@ async function applyYoutubeTranslation(transConfig) {
 	} else {
 		// Remove translation audio iframe
 		languageIframeUrl.value = null;
-		// Unmute the main player using postMessage after a short delay
+		// Restore the main player unless the organiser asked to start muted
 		setTimeout(() => {
 			if (updateToken !== translationUpdateToken) return;
+			if (module.value?.config?.startMuted) return;
 			unmuteYouTubePlayer();
 		}, 100);
 	}
@@ -346,6 +347,10 @@ onBeforeUnmount(() => {
 	// TODO move to store?
 	if (props.room) api.call('room.leave', { room: props.room.id });
 });
+
+function hasAudioOnlyYoutubeTranslation() {
+	return Boolean(youtubeTranslation.value?.url && !youtubeTranslation.value?.useVideo);
+}
 
 function muteYouTubePlayer() {
 	if (!iframeEl.value || !iframeEl.value.contentWindow) return;
@@ -585,8 +590,10 @@ async function initializeIframe(mute, skipConsentCheck = false) {
 					break;
 				}
 				const config = module.value.config || {};
-				const shouldStartMuted = mute || !!config.startMuted;
-				const shouldAutoplay = autoplay.value && !config.hideControls && shouldStartMuted;
+				const shouldStartMuted = Boolean(
+					mute || config.startMuted || hasAudioOnlyYoutubeTranslation()
+				);
+				const shouldAutoplay = Boolean(autoplay.value && !config.hideControls);
 				iframeUrl = getYoutubeUrl(
 					ytid,
 					shouldAutoplay,
@@ -657,8 +664,7 @@ async function initializeIframe(mute, skipConsentCheck = false) {
 		if (isYouTube) {
 			iframe.onload = () => {
 				subscribeToYouTubePlayerEvents();
-				// If translation is already selected, mute the main player (if audio-only)
-				if (youtubeTranslation.value?.url && !youtubeTranslation.value?.useVideo) {
+				if (hasAudioOnlyYoutubeTranslation()) {
 					setTimeout(() => muteYouTubePlayer(), 1000);
 				}
 			};

--- a/app/eventyay/webapp/video/src/views/admin/rooms/types-edit/stage.vue
+++ b/app/eventyay/webapp/video/src/views/admin/rooms/types-edit/stage.vue
@@ -46,7 +46,7 @@
 				bunt-switch(name="loop", v-model="loop", label="Loop")
 				bunt-switch(name="modestBranding", v-model="modestBranding", label="Enable Modest Branding")
 				bunt-switch(name="startMuted", v-model="startMuted", label="Start muted")
-				bunt-switch(name="hideControls", v-model="hideControls", label="Hide Controls", hint="Note: Hiding controls disables autoplay (browsers require muted autoplay, but users can't unmute without controls)")
+				bunt-switch(name="hideControls", v-model="hideControls", label="Hide Controls", hint="Note: Hiding controls disables autoplay so the stream can start with sound when the viewer clicks play.")
 				bunt-switch(name="noRelated", v-model="noRelated", label="Limit related videos to same channel")
 				bunt-switch(name="disableKb", v-model="disableKb", label="Disable Keyboard Controls")
 				bunt-switch(name="showInfo", v-model="showInfo", label="Hide Video Info")
@@ -91,7 +91,6 @@ function getDefaultStreamConfig(streamSource, playbackMode = PLAYBACK_MODE_ALWAY
 	} else if (streamSource === 'youtube') {
 		config.ytid = ''
 		config.languageUrls = []
-		config.startMuted = true
 	} else if (streamSource === 'iframe') {
 		config.url = ''
 	}


### PR DESCRIPTION
## Summary
- YouTube room streams no longer start muted just because player controls are visible (the default room setup).
- Autoplay is independent of mute. Mute is applied only for **Start muted**, an audio-only translation track, or an explicit caller mute.
- New YouTube rooms default to unmuted. Existing rooms with **Start muted** saved keep that setting until organisers turn it off.

Fixes #4558

## Test plan
- [x] ESLint on the three changed Vue files
- [x] Playback matrix check: default unmuted autoplay, hidden controls skip autoplay, Start muted / translation / caller mute still mute, autoplay-off stays paused
- [ ] Open a typical YouTube room (controls visible, autoplay on, Start muted off) and confirm the stream starts with sound
- [ ] Enable **Start muted** and confirm the stream still autoplays muted
- [ ] Enable an audio-only translation track and confirm the main player mutes; disable it and confirm sound returns unless Start muted is on
- [ ] Hide controls and confirm autoplay is off so a click can start playback with sound
- [ ] Repeat for always-on and schedule-driven YouTube rooms

## Risk and Rollback
Browsers may still block unmuted autoplay on a first visit; in that case the video stays paused until the viewer clicks play, then it plays with sound. Revert this commit to restore the previous muted-autoplay default.

## Summary by Sourcery

Allow YouTube room streams to autoplay with sound by default while retaining intentional muting behavior.

Bug Fixes:
- Stop YouTube room streams from being force-muted when autoplay is enabled and player controls are visible.
- Preserve muting for Start muted, audio-only translation tracks, and explicit caller mute requests while restoring sound when those conditions no longer apply.

Enhancements:
- Make new YouTube rooms default to unmuted and clarify that hiding controls disables autoplay rather than enabling muted playback.