### PR TITLE
fix(video): fix room list video dropdown

### DIFF
--- a/app/eventyay/features/live/consumers.py
+++ b/app/eventyay/features/live/consumers.py
@@ -154,23 +154,22 @@ class MainConsumer(AsyncJsonWebsocketConsumer):
 
     # Receive message from WebSocket
     async def receive_json(self, content, **kargs):
-        self.content = content
-
         if content[0] == "ping":
             await self.send_json(["pong", content[1]])
             self.last_conn_ping = await ping_connection(self.last_conn_ping, self.user)
             return
 
         if not self.event:
-            await self.send_error("event.unknown_event", close=True)
+            await self.send_error("event.unknown_event", close=True, request=content)
             return
 
         if not self.user:
             if content[0] == "authenticate":
                 await self._maybe_refresh(self.event, allowed_age=30)
+                self.content = content
                 await self.components["user"].login(content[-1])
             else:
-                await self.send_error("protocol.unauthenticated")
+                await self.send_error("protocol.unauthenticated", request=content)
             return
 
         async with statsd() as s:
@@ -179,18 +178,17 @@ class MainConsumer(AsyncJsonWebsocketConsumer):
         namespace = content[0].split(".")[0]
         component = self.components.get(namespace)
         if component:
-            try:
+            async with self.command_lock:
                 await self._maybe_refresh(self.event, allowed_age=900)
                 await self._maybe_refresh(self.user, allowed_age=30)
-                # Room command decorators temporarily store the selected room
-                # on a shared module instance. Serialize commands so a fast
-                # room transition cannot overwrite that state.
-                async with self.command_lock:
+                # Module handlers temporarily store room state on the module.
+                self.content = content
+                try:
                     await component.dispatch_command(content)
-            except ConsumerException as e:
-                await self.send_error(e.code, e.message)
+                except ConsumerException as e:
+                    await self.send_error(e.code, e.message, request=content)
         else:
-            await self.send_error("protocol.unknown_command")
+            await self.send_error("protocol.unknown_command", request=content)
 
     async def dispatch(self, message):
         if self.conn_time and time.time() - self.conn_time > 3600 * 24 * random.uniform(
@@ -231,7 +229,8 @@ class MainConsumer(AsyncJsonWebsocketConsumer):
             component = self.components.get(namespace)
             if component:
                 if hasattr(component, "dispatch_event"):
-                    return await component.dispatch_event(message)
+                    async with self.command_lock:
+                        return await component.dispatch_event(message)
             else:
                 return await super().dispatch(message)
         except ConnectionClosed:  # pragma: no cover
@@ -253,25 +252,32 @@ class MainConsumer(AsyncJsonWebsocketConsumer):
                     f"error.fatal,event={self.event.pk if self.event else 'None'}"
                 )
 
-    def build_response(self, status, data):
+    def build_response(self, status, data, request=None):
         if data is None:
             data = {}
         response = [status]
-        if len(self.content) == 3:
-            response.append(self.content[1])
+        request_content = request if request is not None else self.content
+        if len(request_content) == 3:
+            response.append(request_content[1])
         response.append(data)
         return response
 
-    async def send_error(self, code, message=None, close=False, details=None):
+    async def send_error(
+        self, code, message=None, close=False, details=None, request=None
+    ):
         data = {"code": code}
         if message:
             data["message"] = message
         if details:
             data["details"] = details
-        await self.send_json(self.build_response("error", data), close=close)
+        await self.send_json(
+            self.build_response("error", data, request=request), close=close
+        )
 
     async def send_success(self, data=None, close=False):
-        await self.send_json(self.build_response("success", data), close=close)
+        await self.send_json(
+            self.build_response("success", data), close=close
+        )
 
     # Override send and receive methods to use orjson and less function calls
 

--- a/app/eventyay/features/live/consumers.py
+++ b/app/eventyay/features/live/consumers.py
@@ -49,6 +49,7 @@ class MainConsumer(AsyncJsonWebsocketConsumer):
         self.room_cache = {}
         self.channel_cache = {}
         self.components = {}
+        self.command_lock = asyncio.Lock()
         self.conn_time = 0
         self.last_conn_ping = 0
 
@@ -181,7 +182,11 @@ class MainConsumer(AsyncJsonWebsocketConsumer):
             try:
                 await self._maybe_refresh(self.event, allowed_age=900)
                 await self._maybe_refresh(self.user, allowed_age=30)
-                await component.dispatch_command(content)
+                # Room command decorators temporarily store the selected room
+                # on a shared module instance. Serialize commands so a fast
+                # room transition cannot overwrite that state.
+                async with self.command_lock:
+                    await component.dispatch_command(content)
             except ConsumerException as e:
                 await self.send_error(e.code, e.message)
         else:

--- a/app/eventyay/features/live/consumers.py
+++ b/app/eventyay/features/live/consumers.py
@@ -49,7 +49,6 @@ class MainConsumer(AsyncJsonWebsocketConsumer):
         self.room_cache = {}
         self.channel_cache = {}
         self.components = {}
-        self.command_lock = asyncio.Lock()
         self.conn_time = 0
         self.last_conn_ping = 0
 
@@ -154,22 +153,23 @@ class MainConsumer(AsyncJsonWebsocketConsumer):
 
     # Receive message from WebSocket
     async def receive_json(self, content, **kargs):
+        self.content = content
+
         if content[0] == "ping":
             await self.send_json(["pong", content[1]])
             self.last_conn_ping = await ping_connection(self.last_conn_ping, self.user)
             return
 
         if not self.event:
-            await self.send_error("event.unknown_event", close=True, request=content)
+            await self.send_error("event.unknown_event", close=True)
             return
 
         if not self.user:
             if content[0] == "authenticate":
                 await self._maybe_refresh(self.event, allowed_age=30)
-                self.content = content
                 await self.components["user"].login(content[-1])
             else:
-                await self.send_error("protocol.unauthenticated", request=content)
+                await self.send_error("protocol.unauthenticated")
             return
 
         async with statsd() as s:
@@ -178,17 +178,14 @@ class MainConsumer(AsyncJsonWebsocketConsumer):
         namespace = content[0].split(".")[0]
         component = self.components.get(namespace)
         if component:
-            async with self.command_lock:
+            try:
                 await self._maybe_refresh(self.event, allowed_age=900)
                 await self._maybe_refresh(self.user, allowed_age=30)
-                # Module handlers temporarily store room state on the module.
-                self.content = content
-                try:
-                    await component.dispatch_command(content)
-                except ConsumerException as e:
-                    await self.send_error(e.code, e.message, request=content)
+                await component.dispatch_command(content)
+            except ConsumerException as e:
+                await self.send_error(e.code, e.message)
         else:
-            await self.send_error("protocol.unknown_command", request=content)
+            await self.send_error("protocol.unknown_command")
 
     async def dispatch(self, message):
         if self.conn_time and time.time() - self.conn_time > 3600 * 24 * random.uniform(
@@ -229,8 +226,7 @@ class MainConsumer(AsyncJsonWebsocketConsumer):
             component = self.components.get(namespace)
             if component:
                 if hasattr(component, "dispatch_event"):
-                    async with self.command_lock:
-                        return await component.dispatch_event(message)
+                    return await component.dispatch_event(message)
             else:
                 return await super().dispatch(message)
         except ConnectionClosed:  # pragma: no cover
@@ -252,32 +248,25 @@ class MainConsumer(AsyncJsonWebsocketConsumer):
                     f"error.fatal,event={self.event.pk if self.event else 'None'}"
                 )
 
-    def build_response(self, status, data, request=None):
+    def build_response(self, status, data):
         if data is None:
             data = {}
         response = [status]
-        request_content = request if request is not None else self.content
-        if len(request_content) == 3:
-            response.append(request_content[1])
+        if len(self.content) == 3:
+            response.append(self.content[1])
         response.append(data)
         return response
 
-    async def send_error(
-        self, code, message=None, close=False, details=None, request=None
-    ):
+    async def send_error(self, code, message=None, close=False, details=None):
         data = {"code": code}
         if message:
             data["message"] = message
         if details:
             data["details"] = details
-        await self.send_json(
-            self.build_response("error", data, request=request), close=close
-        )
+        await self.send_json(self.build_response("error", data), close=close)
 
     async def send_success(self, data=None, close=False):
-        await self.send_json(
-            self.build_response("success", data), close=close
-        )
+        await self.send_json(self.build_response("success", data), close=close)
 
     # Override send and receive methods to use orjson and less function calls
 

--- a/app/eventyay/webapp/video/src/components/VideoProviderDropdown.vue
+++ b/app/eventyay/webapp/video/src/components/VideoProviderDropdown.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
-.c-video-provider-dropdown(v-if="canManage", @click.stop, @keydown.stop)
+.c-video-provider-dropdown(v-if="canManage", :class="{open}", @click.prevent.stop, @keydown.stop)
 	template(v-if="providers.length")
-		menu-dropdown(v-model="open", :placement="placement", :offset="offset")
+		menu-dropdown(v-model="open", :placement="placement", :strategy="strategy", :offset="offset")
 			template(#button="{toggle}")
 				bunt-button.dropdown-toggle(
 					:class="buttonClass",
@@ -66,6 +66,10 @@ export default {
 		placement: {
 			type: String,
 			default: 'bottom-start'
+		},
+		strategy: {
+			type: String,
+			default: 'absolute'
 		}
 	},
 	emits: ['select'],
@@ -170,6 +174,9 @@ export default {
 	display: inline-flex
 	flex-direction: column
 	align-items: flex-end
+	z-index: 1
+	&.open
+		z-index: 1200
 	.dropdown-toggle
 		display: inline-flex
 		align-items: center
@@ -196,6 +203,8 @@ export default {
 		display: flex
 		flex-direction: column
 		min-width: 220px
+		position: relative
+		z-index: 1200
 	.provider-option
 		display: flex
 		align-items: center

--- a/app/eventyay/webapp/video/src/views/admin/rooms/RoomListItem.vue
+++ b/app/eventyay/webapp/video/src/views/admin/rooms/RoomListItem.vue
@@ -15,6 +15,7 @@ router-link.c-room-list-item.table-row(:to="{name: 'admin:rooms:item', params: {
 				label="Add Video",
 				variant="action",
 				placement="bottom-end",
+				strategy="fixed",
 				@select="addVideo"
 			)
 </template>


### PR DESCRIPTION
## Summary
- Prevent the room-list Add Video control from activating its parent room navigation link.
- Keep the dropdown above the room table with fixed positioning and an elevated stacking order.
- Remove the ineffective WebSocket locking change; room-transition/server-error behavior is intentionally left unchanged until the actual traceback or client WebSocket sequence identifies the cause.

## Test plan
- [x] `npm --prefix app/eventyay/webapp/video run lint`
- [x] `python -m py_compile app/eventyay/features/live/consumers.py`
- [x] `git diff --check`
- [ ] Open Add Video from a room name without navigating away.
- [ ] Confirm the dropdown renders above the room table.
- [ ] Save a room configuration and immediately open the room from the sidebar; capture the server traceback/WebSocket messages if the fatal error persists.

## Summary by Sourcery

Fix room-list video dropdown interactions and positioning so it opens without navigating away and remains above the room table.

Bug Fixes:
- Prevent the room-list Add Video control from triggering navigation to the parent room.
- Ensure the Add Video dropdown remains visible above the room table.

Enhancements:
- Support configurable dropdown positioning and elevated stacking while open.