### PR TITLE
fix(orders): make Report exporter a built-in always-on feature

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/orders/export.html
+++ b/app/eventyay/control/templates/pretixcontrol/orders/export.html
@@ -41,33 +41,44 @@
 {% block content %}
     {% trans "Data export" as header_title_var %}
     {% captureas header_extra_var %}
-        {% if "identifier" in request.GET %}
+        {% if 'identifier' in request.GET %}
             <a href="?" class="btn btn-default">{% trans "Show all" %}</a>
         {% endif %}
     {% endcaptureas %}
     {% include "common/includes/header_nav.html" with header_title=header_title_var header_title_extra=header_extra_var header_component_link="pretixcontrol/event/component_link.html" %}
-    {% for e in exporters %}
-        <details class="panel panel-default" {% if "identifier" in request.GET or "exporter" in request.POST %}open{% endif %}>
-            <summary class="panel-heading">
-                <h3 class="panel-title">
-                    {{ e.verbose_name }}
-                    <i class="fa fa-angle-down collapse-indicator"></i>
-                </h3>
-            </summary>
-            <div id="{{ e.identifier }}">
-                <div class="panel-body">
-                    <form action="{% url "control:event.orders.export.do" event=request.event.slug organizer=request.organizer.slug %}"
-                            method="post" class="form-horizontal" data-asynctask data-asynctask-download
-                            data-asynctask-long>
-                        {% csrf_token %}
-                        <input type="hidden" name="exporter" value="{{ e.identifier }}" />
-                        {% bootstrap_form e.form layout='control' %}
-                        <button class="btn btn-primary pull-right flip" type="submit">
-                            <span class="icon icon-upload"></span> {% trans "Start export" %}
-                        </button>
-                    </form>
+    {% if exporters %}
+        {% for e in exporters %}
+            <details class="panel panel-default" {% if 'identifier' in request.GET or 'exporter' in request.POST %}open{% endif %}>
+                <summary class="panel-heading">
+                    <h3 class="panel-title">
+                        {{ e.verbose_name }}
+                        <i class="fa fa-angle-down collapse-indicator"></i>
+                    </h3>
+                </summary>
+                <div id="{{ e.identifier }}">
+                    <div class="panel-body">
+                        <form action="{% url 'control:event.orders.export.do' event=request.event.slug organizer=request.organizer.slug %}"
+                                method="post" class="form-horizontal" data-asynctask data-asynctask-download
+                                data-asynctask-long>
+                            {% csrf_token %}
+                            <input type="hidden" name="exporter" value="{{ e.identifier }}" />
+                            {% bootstrap_form e.form layout='control' %}
+                            <button class="btn btn-primary pull-right flip" type="submit">
+                                <span class="icon icon-upload"></span> {% trans "Start export" %}
+                            </button>
+                        </form>
+                    </div>
                 </div>
-            </div>
-        </details>
-    {% endfor %}
+            </details>
+        {% endfor %}
+    {% else %}
+        <div class="alert alert-info">
+            {% if 'identifier' in request.GET %}
+                {% trans "No export matching this request is available." %}
+                <a href="?">{% trans "Show all available exports" %}</a>
+            {% else %}
+                {% trans "No data exports are available for this event." %}
+            {% endif %}
+        </div>
+    {% endif %}
 {% endblock %}

--- a/app/eventyay/plugins/reports/apps.py
+++ b/app/eventyay/plugins/reports/apps.py
@@ -12,8 +12,13 @@ class ReportsApp(AppConfig):
     class EventyayPluginMeta:
         name = _('Report exporter')
         version = version
-        category = 'FORMAT'
-        description = _('This plugin allows you to generate printable reports about your sales.')
+        # Built-in platform feature: always active, hidden from organizer plugin lists
+        # (same pattern as check-in list exporter).
+        visible = False
+        description = _(
+            'Built-in printable sales reports (order overview PDF and tax reports). '
+            'Always available; not managed as an optional plugin.'
+        )
 
     def ready(self):
         from . import signals  # NOQA

--- a/app/eventyay/plugins/reports/apps.py
+++ b/app/eventyay/plugins/reports/apps.py
@@ -12,8 +12,6 @@ class ReportsApp(AppConfig):
     class EventyayPluginMeta:
         name = _('Report exporter')
         version = version
-        # Built-in platform feature: always active, hidden from organizer plugin lists
-        # (same pattern as check-in list exporter).
         visible = False
         description = _(
             'Built-in printable sales reports (order overview PDF and tax reports). '

--- a/app/tests/tickets/plugins/reports/test_reports_always_on.py
+++ b/app/tests/tickets/plugins/reports/test_reports_always_on.py
@@ -1,0 +1,60 @@
+import pytest
+from django.utils.timezone import now
+from django_scopes import scope
+
+from eventyay.base.models import Event, Organizer, Team, User
+from eventyay.base.signals import register_data_exporters
+
+
+@pytest.fixture
+def event_without_reports_plugin():
+    organizer = Organizer.objects.create(name='Dummy', slug='dummy-reports')
+    event = Event.objects.create(
+        organizer=organizer,
+        name='Dummy',
+        slug='dummy-reports',
+        date_from=now(),
+        # Intentionally omit eventyay.plugins.reports — it must still work.
+        plugins='eventyay.plugins.banktransfer',
+    )
+    user = User.objects.create_user('reports@dummy.dummy', 'dummy')
+    team = Team.objects.create(organizer=organizer, can_view_orders=True, can_change_orders=True)
+    team.members.add(user)
+    team.limit_events.add(event)
+    return event, user
+
+
+@pytest.mark.django_db
+def test_reports_plugin_is_hidden_from_organizer_plugin_list(event_without_reports_plugin):
+    event, _user = event_without_reports_plugin
+    with scope(event=event):
+        assert 'eventyay.plugins.reports' not in event.available_plugins
+        assert 'eventyay.plugins.checkinlists' not in event.available_plugins
+
+
+@pytest.mark.django_db
+def test_pdfreport_exporter_registers_without_plugin_enabled(event_without_reports_plugin):
+    event, _user = event_without_reports_plugin
+    with scope(event=event):
+        identifiers = [response(event).identifier for _receiver, response in register_data_exporters.send(event)]
+    assert 'pdfreport' in identifiers
+    assert 'ordertaxes' in identifiers
+    assert 'ordertaxeslist' in identifiers
+
+
+@pytest.mark.django_db
+def test_orders_export_page_shows_pdfreport_without_plugin_enabled(client, event_without_reports_plugin):
+    event, user = event_without_reports_plugin
+    assert client.login(email='reports@dummy.dummy', password='dummy')
+    url = f'/control/event/{event.organizer.slug}/{event.slug}/orders/export/'
+    response = client.get(url)
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert 'Data export' in content
+    assert 'pdfreport' in content
+
+    filtered = client.get(f'{url}?identifier=pdfreport')
+    assert filtered.status_code == 200
+    filtered_content = filtered.content.decode()
+    assert 'pdfreport' in filtered_content
+    assert 'No export matching this request is available.' not in filtered_content

--- a/app/tests/tickets/plugins/reports/test_reports_always_on.py
+++ b/app/tests/tickets/plugins/reports/test_reports_always_on.py
@@ -25,7 +25,7 @@ def event_without_reports_plugin():
 
 
 @pytest.mark.django_db
-def test_reports_plugin_is_hidden_from_organizer_plugin_list(event_without_reports_plugin):
+def test_reports_plugin_is_hidden_from_event_available_plugins(event_without_reports_plugin):
     event, _user = event_without_reports_plugin
     with scope(event=event):
         assert 'eventyay.plugins.reports' not in event.available_plugins
@@ -58,3 +58,15 @@ def test_orders_export_page_shows_pdfreport_without_plugin_enabled(client, event
     filtered_content = filtered.content.decode()
     assert 'pdfreport' in filtered_content
     assert 'No export matching this request is available.' not in filtered_content
+
+@pytest.mark.django_db
+def test_orders_export_page_shows_empty_state_for_unknown_identifier(client, event_without_reports_plugin):
+    event, user = event_without_reports_plugin
+    assert client.login(email='reports@dummy.dummy', password='dummy')
+    url = f'/control/event/{event.organizer.slug}/{event.slug}/orders/export/'
+    
+    filtered = client.get(f'{url}?identifier=unknown_exporter_123')
+    assert filtered.status_code == 200
+    filtered_content = filtered.content.decode()
+    assert 'No export matching this request is available.' in filtered_content
+    assert 'Show all available exports' in filtered_content


### PR DESCRIPTION
## Summary
- Make Report exporter always active and hide it from organizer plugin lists (`visible = False`), matching the check-in list exporter pattern
- Fix blank Orders → Export / `?identifier=pdfreport` when the plugin was disabled (#5207)
- Show an informational empty state when no exporters match a request

https://github.com/user-attachments/assets/c851c894-a8b1-4af9-bf72-e32cd8042406

## Test plan
- [x] With Report exporter not enabled on an event, open Orders → Export and confirm Data export options render (including report PDF)
- [x] Open Orders overview → Export PDF (`?identifier=pdfreport`) and confirm it is not blank
- [x] Confirm Report exporter no longer appears under Plugins → Output and export formats
- [x] Confirm other optional FORMAT plugins still appear and can be toggled
- [x] `pytest tests/tickets/plugins/reports/test_reports_always_on.py`

Closes #5207

## Summary by Sourcery

Make report exporting always available as a built-in feature and improve empty-state handling for unavailable data exports.

Bug Fixes:
- Ensure the built-in report exporters are available even when the reports plugin is not enabled, preventing blank Orders export pages and filtered PDF report requests.
- Display an informational empty state when no exporters match the requested filter.

Enhancements:
- Make the Report exporter an always-on built-in feature hidden from organizer plugin lists, while retaining optional plugin management for other export formats.

Tests:
- Add coverage confirming report exporters register, remain hidden from plugin lists, and render on unconfigured events.

## Summary by Sourcery

Make report exporting an always-on built-in capability and provide clear feedback when no matching export is available.

Bug Fixes:
- Ensure built-in report exporters remain available when the reports plugin is not enabled, preventing blank Orders export pages and filtered PDF report requests.
- Display an informational empty state when no exporter matches the requested filter.

Enhancements:
- Hide the Report exporter from organizer-managed plugin lists while keeping other optional export plugins configurable.

Tests:
- Add coverage for always-on report exporter registration, plugin visibility, successful unconfigured-event export pages, and unknown-exporter empty states.