### PR TITLE
feat(video): add manual sync button for interpretation services

### DIFF
--- a/app/eventyay/webapp/video/src/lib/interpretation-language-streams.js
+++ b/app/eventyay/webapp/video/src/lib/interpretation-language-streams.js
@@ -40,3 +40,16 @@ export function normalizeLanguageStreamEntry(entry) {
 export function defaultLanguageStreamEntry() {
 	return { language: '', youtube_id: '', use_video: false }
 }
+
+export async function syncInterpretationServices(store, roomId) {
+	const response = await fetch(interpretationApiUrl(store, roomId, 'sync/'), {
+		method: 'POST',
+		headers: interpretationAuthHeaders(),
+		credentials: 'include',
+	})
+	const data = await response.json().catch(() => ({}))
+	if (!response.ok) {
+		throw new Error(apiErrorDetail(data) || 'Could not sync interpretation services')
+	}
+	return data
+}

--- a/app/eventyay/webapp/video/src/lib/interpretation-language-streams.js
+++ b/app/eventyay/webapp/video/src/lib/interpretation-language-streams.js
@@ -44,7 +44,7 @@ export function defaultLanguageStreamEntry() {
 export async function syncInterpretationServices(store, roomId) {
 	const response = await fetch(interpretationApiUrl(store, roomId, 'sync/'), {
 		method: 'POST',
-		headers: interpretationAuthHeaders(),
+		headers: interpretationAuthHeaders(true),
 		credentials: 'include',
 	})
 	const data = await response.json().catch(() => ({}))

--- a/app/eventyay/webapp/video/src/views/admin/rooms/EditForm.vue
+++ b/app/eventyay/webapp/video/src/views/admin/rooms/EditForm.vue
@@ -14,6 +14,7 @@
 			sidebar-addons(v-if="inferredType && inferredType.id === 'stage'", :config="config", :modules="modules", :creating="creating")
 	.ui-form-actions
 		bunt-button.btn-save(@click="save", :loading="saving", :error="!!error") {{ creating ? $t('Create') : $t('Save') }}
+		bunt-button.btn-sync(v-if="!creating && interpretationAdmin.usePluginStreams", @click="syncServices", :loading="syncing", :error="!!syncError", style="margin-left: 10px") {{ $t('Sync Services') }}
 		.errors {{ error || validationErrors.join(', ') }}
 </template>
 <script>
@@ -39,6 +40,7 @@ import {
 	cloneLanguageStreamEntries,
 	fetchInterpretationLanguageStreams,
 	saveInterpretationLanguageStreams,
+	syncInterpretationServices,
 } from 'lib/interpretation-language-streams'
 
 export default {
@@ -73,7 +75,9 @@ export default {
 				'channel-zoom': ChannelZoom,
 			}),
 			saving: false,
+			syncing: false,
 			error: null,
+			syncError: null,
 			interpretationAdmin: {
 				usePluginStreams: false,
 				languageStreams: [],
@@ -225,6 +229,16 @@ export default {
 				this.saving = false
 				this.error = error.message || error
 			}
+		},
+		async syncServices() {
+			this.syncError = null
+			this.syncing = true
+			try {
+				await syncInterpretationServices(this.$store, this.config.id)
+			} catch (error) {
+				this.syncError = error.message || error
+			}
+			this.syncing = false
 		},
 		clearOpenStreamScheduleCreateQuery() {
 			if (this.$route.query.schedule !== 'new') return


### PR DESCRIPTION
This adds a manual 'Sync Services' button to the room editor to trigger Voxbento sync. Note: Requires corresponding backend endpoint in fossasia/eventyay-interpretation#105.

## Summary by Sourcery

Enable administrators to manually synchronize interpretation services from the room editor.

New Features:
- Add a manual “Sync Services” action to the room editor for interpretation services.
- Trigger interpretation service synchronization through the backend API and surface loading and error states in the editor.