### PR TITLE
fix(video): isolate interpretation source UI from normal language streams

### DIFF
--- a/app/eventyay/webapp/video/src/views/admin/rooms/types-edit/stage.vue
+++ b/app/eventyay/webapp/video/src/views/admin/rooms/types-edit/stage.vue
@@ -32,6 +32,7 @@
 		// Language and URL input for YouTube stream
 		.language-urls(v-if="modules['livestream.youtube']")
 			LanguageAudioSourceList(
+				v-if="!showPluginLanguageStreams"
 				:title="$t('Languages and Audio Source')"
 				:entries="modules['livestream.youtube'].config.languageUrls"
 			)


### PR DESCRIPTION
This PR fixes a UI duplication and validation issue in the Video Room Editor. 

When the interpretation plugin is enabled, it now completely replaces the normal 'Languages and Audio Source' box with the 'Interpretation source' box. This prevents the user from being confused by two identical input boxes, and ensures that the Vue frontend uses the correct payload array for the backend to auto-provision VoxBento booths.


<img width="3340" height="2848" alt="image" src="https://github.com/user-attachments/assets/24bb48f9-d0aa-4cac-b7a3-3b4a5d68caf1" />




## Summary by Sourcery

Bug Fixes:
- Prevent the standard language and audio source input from appearing alongside the interpretation source UI when interpretation mode is enabled.