### PR TITLE
Improve My Orders filter UX and extend filter parameters

### DIFF
--- a/app/eventyay/eventyay_common/forms/filters.py
+++ b/app/eventyay/eventyay_common/forms/filters.py
@@ -42,6 +42,14 @@ class UserOrderFilterForm(forms.Form):
         widget=DatePickerWidget,
     )
 
+    def clean(self):
+        data = super().clean()
+        date_from = data.get('date_from')
+        date_to = data.get('date_to')
+        if date_from and date_to and date_from > date_to:
+            self.add_error('date_from', _('The start date cannot be later than the end date.'))
+        return data
+
 
     def __init__(self, *args, **kwargs):
         user = kwargs.pop('user', None)  # Get the user from the kwargs

--- a/app/eventyay/eventyay_common/forms/filters.py
+++ b/app/eventyay/eventyay_common/forms/filters.py
@@ -2,7 +2,8 @@ from django import forms
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 
-from eventyay.base.models import Event
+from eventyay.base.forms.widgets import DatePickerWidget
+from eventyay.base.models import Event, Order
 
 
 class UserOrderFilterForm(forms.Form):
@@ -13,6 +14,34 @@ class UserOrderFilterForm(forms.Form):
         widget=forms.Select(attrs={'class': 'form-control'}),
         empty_label=_('Select an Event'),
     )
+    code = forms.CharField(
+        required=False,
+        label=_('Order code'),
+        widget=forms.TextInput(attrs={'class': 'form-control', 'placeholder': _('Order code')}),
+    )
+    status = forms.ChoiceField(
+        required=False,
+        label=_('Status'),
+        choices=(
+            ('', _('All statuses')),
+            (Order.STATUS_PENDING, _('Pending')),
+            (Order.STATUS_PAID, _('Paid')),
+            (Order.STATUS_EXPIRED, _('Expired')),
+            (Order.STATUS_CANCELED, _('Canceled')),
+        ),
+        widget=forms.Select(attrs={'class': 'form-control'}),
+    )
+    date_from = forms.DateField(
+        required=False,
+        label=_('Date from'),
+        widget=DatePickerWidget,
+    )
+    date_to = forms.DateField(
+        required=False,
+        label=_('Date to'),
+        widget=DatePickerWidget,
+    )
+
 
     def __init__(self, *args, **kwargs):
         user = kwargs.pop('user', None)  # Get the user from the kwargs

--- a/app/eventyay/eventyay_common/templates/eventyay_common/orders/orders.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/orders/orders.html
@@ -19,8 +19,20 @@
                 <div class="advanced-filter-field" style="flex: 1 1 0; margin-bottom: 0;">
                     {% bootstrap_field filter_form.event layout='inline' %}
                 </div>
+                <div class="advanced-filter-field" style="flex: 1 1 0; margin-bottom: 0;">
+                    {% bootstrap_field filter_form.code layout='inline' %}
+                </div>
+                <div class="advanced-filter-field" style="flex: 1 1 0; margin-bottom: 0;">
+                    {% bootstrap_field filter_form.status layout='inline' %}
+                </div>
+                <div class="advanced-filter-field" style="flex: 1 1 0; margin-bottom: 0;">
+                    {% bootstrap_field filter_form.date_from layout='inline' %}
+                </div>
+                <div class="advanced-filter-field" style="flex: 1 1 0; margin-bottom: 0;">
+                    {% bootstrap_field filter_form.date_to layout='inline' %}
+                </div>
                 <div class="advanced-filter-search-actions">
-                    <button type="submit" class="btn btn-primary" aria-label="{% trans 'Apply filters' %}">
+                    <button type="submit" class="btn btn-primary" aria-label="{% trans 'Apply filters' %}" title="{% trans 'Apply filters' %}">
                         <span class="fa fa-filter" aria-hidden="true"></span>
                     </button>
                     <a href="{{ request.path }}" class="btn btn-default btn-clear-filter" aria-label="{% trans 'Clear filters' %}" title="{% trans 'Clear filters' %}">

--- a/app/eventyay/eventyay_common/views/orders.py
+++ b/app/eventyay/eventyay_common/views/orders.py
@@ -1,13 +1,16 @@
+from datetime import datetime, time
 from logging import getLogger
 
 from django.db.models import Q
 from django.shortcuts import redirect
+from django.utils.timezone import get_current_timezone, make_aware
 from django.views.generic.list import ListView
 
 from eventyay.base.models import Order
 from eventyay.control.views import PaginationMixin
 
 from ..forms.filters import UserOrderFilterForm
+
 
 logger = getLogger(__name__)
 
@@ -20,12 +23,31 @@ class MyOrdersView(PaginationMixin, ListView):
         user = self.request.user
         qs = Order.objects.filter(Q(email__iexact=user.email)).select_related('event').order_by('-datetime')
 
-        # Filter by event if provided
         filter_form = UserOrderFilterForm(self.request.GET, user=user, request=self.request)
         if filter_form.is_valid():
-            event = filter_form.cleaned_data['event']
-            if event:
-                qs = qs.filter(event=event)
+            fdata = filter_form.cleaned_data
+            if fdata.get('event'):
+                qs = qs.filter(event=fdata['event'])
+
+            if fdata.get('code'):
+                code_query = fdata['code'].strip()
+                if code_query:
+                    qs = qs.filter(
+                        Q(code__icontains=code_query)
+                        | Q(code__icontains=Order.normalize_code(code_query))
+                    )
+
+            if fdata.get('status'):
+                qs = qs.filter(status=fdata['status'])
+
+            tz = get_current_timezone()
+            if fdata.get('date_from'):
+                start_dt = make_aware(datetime.combine(fdata['date_from'], time.min), tz)
+                qs = qs.filter(datetime__gte=start_dt)
+
+            if fdata.get('date_to'):
+                end_dt = make_aware(datetime.combine(fdata['date_to'], time.max), tz)
+                qs = qs.filter(datetime__lte=end_dt)
 
         return qs
 
@@ -36,11 +58,14 @@ class MyOrdersView(PaginationMixin, ListView):
 
     def get(self, request, *args, **kwargs):
         filter_form = UserOrderFilterForm(self.request.GET, user=self.request.user, request=self.request)
-        # If filter form is invalid, strip the 'event' from URL and redirect to this new URL.
+        # If filter form is invalid, strip invalid keys from URL and redirect to new URL.
         if not filter_form.is_valid():
             new_url_query = request.GET.copy()
-            new_url_query.pop('event', None)
-            new_url = request.path + '?' + new_url_query.urlencode()
+            for field_name in filter_form.errors:
+                new_url_query.pop(field_name, None)
+            new_url = request.path
+            if new_url_query:
+                new_url += '?' + new_url_query.urlencode()
             logger.info('To redirect to "%s" because the filter values are invalid.', new_url)
             return redirect(new_url)
         return super().get(request, *args, **kwargs)

--- a/app/tests/eventyay_common/test_user_orders.py
+++ b/app/tests/eventyay_common/test_user_orders.py
@@ -1,0 +1,250 @@
+import datetime
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from django_scopes import scopes_disabled
+
+from eventyay.base.models import Event, Order
+
+
+@pytest.mark.django_db
+def test_my_orders_view_apply_button_tooltip_and_fields(client, user, event):
+    client.force_login(user)
+    with scopes_disabled():
+        Order.objects.create(
+            code="ORD123",
+            status=Order.STATUS_PAID,
+            datetime=timezone.now(),
+            expires=timezone.now() + datetime.timedelta(days=1),
+            total=10,
+            event=event,
+            email=user.email,
+        )
+
+    url = reverse("eventyay_common:orders")
+    response = client.get(url)
+    assert response.status_code == 200
+
+    content = response.content.decode()
+    assert 'title="Apply filters"' in content
+    assert 'name="event"' in content
+    assert 'name="code"' in content
+    assert 'name="status"' in content
+    assert 'name="date_from"' in content
+    assert 'name="date_to"' in content
+
+
+@pytest.mark.django_db
+def test_user_orders_filtering_by_event(client, user, event, organizer):
+    client.force_login(user)
+    with scopes_disabled():
+        event2 = Event.objects.create(
+            organizer=organizer,
+            name="Event 2",
+            slug="event-2",
+            date_from=timezone.now(),
+            live=True,
+            is_public=True,
+        )
+        order1 = Order.objects.create(
+            code="ORD001",
+            status=Order.STATUS_PAID,
+            datetime=timezone.now(),
+            expires=timezone.now() + datetime.timedelta(days=1),
+            total=10,
+            event=event,
+            email=user.email,
+        )
+        order2 = Order.objects.create(
+            code="ORD002",
+            status=Order.STATUS_PAID,
+            datetime=timezone.now(),
+            expires=timezone.now() + datetime.timedelta(days=1),
+            total=20,
+            event=event2,
+            email=user.email,
+        )
+
+    url = reverse("eventyay_common:orders")
+    response = client.get(f"{url}?event={event.pk}")
+    assert response.status_code == 200
+    orders = list(response.context["order_list"])
+    assert order1 in orders
+    assert order2 not in orders
+
+
+@pytest.mark.django_db
+def test_user_orders_filtering_by_code_partial_and_normalized(client, user, event):
+    client.force_login(user)
+    with scopes_disabled():
+        order1 = Order.objects.create(
+            code="ABC12345",
+            status=Order.STATUS_PAID,
+            datetime=timezone.now(),
+            expires=timezone.now() + datetime.timedelta(days=1),
+            total=10,
+            event=event,
+            email=user.email,
+        )
+        order2 = Order.objects.create(
+            code="XYZ67890",
+            status=Order.STATUS_PAID,
+            datetime=timezone.now(),
+            expires=timezone.now() + datetime.timedelta(days=1),
+            total=20,
+            event=event,
+            email=user.email,
+        )
+
+    url = reverse("eventyay_common:orders")
+
+    # Partial code match
+    response = client.get(f"{url}?code=ABC123")
+    assert response.status_code == 200
+    orders = list(response.context["order_list"])
+    assert order1 in orders
+    assert order2 not in orders
+
+    # Case-insensitive match
+    response = client.get(f"{url}?code=abc123")
+    assert response.status_code == 200
+    orders = list(response.context["order_list"])
+    assert order1 in orders
+    assert order2 not in orders
+
+
+@pytest.mark.django_db
+def test_user_orders_filtering_by_status(client, user, event):
+    client.force_login(user)
+    with scopes_disabled():
+        order_paid = Order.objects.create(
+            code="PAID01",
+            status=Order.STATUS_PAID,
+            datetime=timezone.now(),
+            expires=timezone.now() + datetime.timedelta(days=1),
+            total=10,
+            event=event,
+            email=user.email,
+        )
+        order_pending = Order.objects.create(
+            code="PEND01",
+            status=Order.STATUS_PENDING,
+            datetime=timezone.now(),
+            expires=timezone.now() + datetime.timedelta(days=1),
+            total=10,
+            event=event,
+            email=user.email,
+        )
+
+    url = reverse("eventyay_common:orders")
+
+    # Filter paid
+    response = client.get(f"{url}?status={Order.STATUS_PAID}")
+    assert response.status_code == 200
+    orders = list(response.context["order_list"])
+    assert order_paid in orders
+    assert order_pending not in orders
+
+    # Filter pending
+    response = client.get(f"{url}?status={Order.STATUS_PENDING}")
+    assert response.status_code == 200
+    orders = list(response.context["order_list"])
+    assert order_pending in orders
+    assert order_paid not in orders
+
+
+@pytest.mark.django_db
+def test_user_orders_filtering_by_date_from_and_date_to(client, user, event):
+    client.force_login(user)
+    now = timezone.now()
+    dt_early = now - datetime.timedelta(days=20)
+    dt_mid = now - datetime.timedelta(days=10)
+    dt_late = now - datetime.timedelta(days=2)
+
+    with scopes_disabled():
+        order_early = Order.objects.create(
+            code="EARLY1",
+            status=Order.STATUS_PAID,
+            datetime=dt_early,
+            expires=dt_early + datetime.timedelta(days=1),
+            total=10,
+            event=event,
+            email=user.email,
+        )
+        order_mid = Order.objects.create(
+            code="MID001",
+            status=Order.STATUS_PAID,
+            datetime=dt_mid,
+            expires=dt_mid + datetime.timedelta(days=1),
+            total=10,
+            event=event,
+            email=user.email,
+        )
+        order_late = Order.objects.create(
+            code="LATE01",
+            status=Order.STATUS_PAID,
+            datetime=dt_late,
+            expires=dt_late + datetime.timedelta(days=1),
+            total=10,
+            event=event,
+            email=user.email,
+        )
+
+    url = reverse("eventyay_common:orders")
+
+    date_from_str = (dt_mid - datetime.timedelta(days=1)).strftime("%Y-%m-%d")
+    date_to_str = (dt_mid + datetime.timedelta(days=1)).strftime("%Y-%m-%d")
+
+    # Filter by date_from and date_to around mid date
+    response = client.get(f"{url}?date_from={date_from_str}&date_to={date_to_str}")
+    assert response.status_code == 200
+    orders = list(response.context["order_list"])
+    assert order_mid in orders
+    assert order_early not in orders
+    assert order_late not in orders
+
+
+@pytest.mark.django_db
+def test_user_orders_combined_filters(client, user, event):
+    client.force_login(user)
+    now = timezone.now()
+    with scopes_disabled():
+        order_target = Order.objects.create(
+            code="MATCH1",
+            status=Order.STATUS_PAID,
+            datetime=now,
+            expires=now + datetime.timedelta(days=1),
+            total=10,
+            event=event,
+            email=user.email,
+        )
+        order_other = Order.objects.create(
+            code="MATCH2",
+            status=Order.STATUS_PENDING,
+            datetime=now,
+            expires=now + datetime.timedelta(days=1),
+            total=10,
+            event=event,
+            email=user.email,
+        )
+
+    url = reverse("eventyay_common:orders")
+    today_str = now.strftime("%Y-%m-%d")
+    response = client.get(
+        f"{url}?event={event.pk}&code=MATCH1&status={Order.STATUS_PAID}&date_from={today_str}&date_to={today_str}"
+    )
+    assert response.status_code == 200
+    orders = list(response.context["order_list"])
+    assert order_target in orders
+    assert order_other not in orders
+
+
+@pytest.mark.django_db
+def test_user_orders_invalid_filter_param_redirect(client, user, event):
+    client.force_login(user)
+    url = reverse("eventyay_common:orders")
+    response = client.get(f"{url}?date_from=invalid-date&code=TEST")
+    assert response.status_code == 302
+    assert "code=TEST" in response.url
+    assert "date_from" not in response.url

--- a/app/tests/eventyay_common/test_user_orders.py
+++ b/app/tests/eventyay_common/test_user_orders.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from django_scopes import scopes_disabled
 
 from eventyay.base.models import Event, Order
+from eventyay.eventyay_common.forms.filters import UserOrderFilterForm
 
 
 @pytest.mark.django_db
@@ -241,10 +242,44 @@ def test_user_orders_combined_filters(client, user, event):
 
 
 @pytest.mark.django_db
+def test_user_order_filter_form_date_range_validation(user):
+    with scopes_disabled():
+        # date_from < date_to is valid
+        form_valid_range = UserOrderFilterForm(
+            {"date_from": "2026-05-01", "date_to": "2026-05-10"},
+            user=user,
+        )
+        assert form_valid_range.is_valid()
+
+        # date_from == date_to is valid
+        form_same_date = UserOrderFilterForm(
+            {"date_from": "2026-05-10", "date_to": "2026-05-10"},
+            user=user,
+        )
+        assert form_same_date.is_valid()
+
+        # date_from > date_to is invalid
+        form_reversed = UserOrderFilterForm(
+            {"date_from": "2026-05-10", "date_to": "2026-05-01"},
+            user=user,
+        )
+        assert not form_reversed.is_valid()
+        assert "date_from" in form_reversed.errors
+
+
+@pytest.mark.django_db
 def test_user_orders_invalid_filter_param_redirect(client, user, event):
     client.force_login(user)
     url = reverse("eventyay_common:orders")
+
+    # Invalid date format
     response = client.get(f"{url}?date_from=invalid-date&code=TEST")
     assert response.status_code == 302
     assert "code=TEST" in response.url
     assert "date_from" not in response.url
+
+    # Reversed date range (date_from > date_to)
+    response_reversed = client.get(f"{url}?date_from=2026-05-10&date_to=2026-05-01&code=TEST")
+    assert response_reversed.status_code == 302
+    assert "code=TEST" in response_reversed.url
+    assert "date_from" not in response_reversed.url


### PR DESCRIPTION
## Summary

Fixes #5234

This PR improves the "My Orders" page filter UX and expands its filtering capabilities.

### Changes

- Added a `title="Apply filters"` tooltip to the Apply Filters button, matching the existing Clear Filters button pattern.
- Added filtering by order code, including partial/normalized code matching.
- Added filtering by order status.
- Added `Date from` and `Date to` filters with timezone-aware day boundaries.
- Preserved the existing event filter behavior.
- Added focused tests covering the new filters, combined filtering, tooltip rendering, and invalid query parameter handling.

### Testing

- `tests/eventyay_common/test_user_orders.py`: 7 tests passed.
- `eventyay_common` test suite: 58 tests passed.
- Ruff checks passed.
- `git diff --check` passed.

No unrelated files or dependency/migration changes were introduced.

## Summary by Sourcery

Expand My Orders filtering and improve the filter form experience.

New Features:
- Extend the My Orders page with order code, status, and date range filtering.

Bug Fixes:
- Handle invalid filter parameters by removing only the invalid fields while preserving valid filters.

Enhancements:
- Improve filter usability with an Apply Filters tooltip and timezone-aware date range handling.

Tests:
- Add coverage for the expanded filters, combined filtering, form validation, invalid parameter handling, and filter controls.