### PR TITLE
Fix AttributeError when feature_flags is a list

### DIFF
--- a/app/eventyay/orga/forms/event.py
+++ b/app/eventyay/orga/forms/event.py
@@ -350,14 +350,14 @@ class FeedbackSettingsForm(ReadOnlyFlag, JsonSubfieldMixin, forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.instance:
-            flags = self.instance.feature_flags or {}
+            flags = self.instance.feature_flags_as_mapping()
             if 'feedback_anonymous_mode' not in flags and flags.get('feedback_allow_anonymous'):
                 self.fields['feedback_anonymous_mode'].initial = 'optional'
 
     def clean(self):
         cleaned_data = super().clean()
         if not cleaned_data.get('use_feedback'):
-            flags = (self.instance.feature_flags or {}) if self.instance else {}
+            flags = self.instance.feature_flags_as_mapping() if self.instance else {}
             for field in [
                 'feedback_close_after_days',
                 'feedback_who_can_comment',
@@ -389,7 +389,7 @@ class FeedbackSettingsForm(ReadOnlyFlag, JsonSubfieldMixin, forms.Form):
 
     def save(self, *args, **kwargs):
         instance = super().save(*args, **kwargs)
-        flags = instance.feature_flags or {}
+        flags = instance.feature_flags_as_mapping()
         mode = flags.get('feedback_anonymous_mode', 'public')
         flags['feedback_allow_anonymous'] = mode in ('optional', 'always')
         instance.feature_flags = flags


### PR DESCRIPTION
Before : 

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6986e29c-2237-413d-a47a-644dff2b25fd" />

After :

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/aed9c39e-e981-4dd5-a455-3e04b0ff3eca" />


This PR fixes a bug in FeedbackSettingsForm where accessing feature_flags caused an AttributeError if it was stored as a list. It now uses feature_flags_as_mapping() to ensure it's safely accessed as a dictionary.

## Summary by Sourcery

Bug Fixes:
- Prevent feedback settings from raising an AttributeError when feature flags are stored as a list by safely normalizing them before access.