### PR TITLE
fix: correct email gateway radio button dependencies

### DIFF
--- a/app/eventyay/orga/forms/email.py
+++ b/app/eventyay/orga/forms/email.py
@@ -80,7 +80,7 @@ class CentralMailSettingsForm(SettingsForm):
         label=_('SendGrid API key'),
         required=False,
         widget=SecretKeySettingsWidget(attrs={
-            'data-display-dependency': '#id_email-email_vendor_0',
+            'data-display-dependency': '#id_email-email_vendor_1',
         }),
     )
     smtp_host = forms.CharField(
@@ -88,7 +88,7 @@ class CentralMailSettingsForm(SettingsForm):
         required=False,
         widget=forms.TextInput(attrs={
             'placeholder': 'mail.example.org',
-            'data-display-dependency': '#id_email-email_vendor_1',
+            'data-display-dependency': '#id_email-email_vendor_0',
         }),
     )
     smtp_port = forms.IntegerField(
@@ -96,7 +96,7 @@ class CentralMailSettingsForm(SettingsForm):
         required=False,
         widget=forms.TextInput(attrs={
             'placeholder': 'e.g. 587, 465, 25 …',
-            'data-display-dependency': '#id_email-email_vendor_1',
+            'data-display-dependency': '#id_email-email_vendor_0',
         }),
     )
     smtp_username = forms.CharField(
@@ -104,14 +104,14 @@ class CentralMailSettingsForm(SettingsForm):
         required=False,
         widget=forms.TextInput(attrs={
             'placeholder': 'myuser@example.org',
-            'data-display-dependency': '#id_email-email_vendor_1',
+            'data-display-dependency': '#id_email-email_vendor_0',
         }),
     )
     smtp_password = SecretKeySettingsField(
         label=_('SMTP password'),
         required=False,
         widget=SecretKeySettingsWidget(attrs={
-            'data-display-dependency': '#id_email-email_vendor_1',
+            'data-display-dependency': '#id_email-email_vendor_0',
         }),
     )
     smtp_use_tls = forms.BooleanField(
@@ -119,7 +119,7 @@ class CentralMailSettingsForm(SettingsForm):
         help_text=_('Commonly enabled on port 587.'),
         required=False,
         widget=forms.CheckboxInput(attrs={
-            'data-display-dependency': '#id_email-email_vendor_1',
+            'data-display-dependency': '#id_email-email_vendor_0',
         }),
     )
     smtp_use_ssl = forms.BooleanField(
@@ -127,7 +127,7 @@ class CentralMailSettingsForm(SettingsForm):
         help_text=_('Commonly enabled on port 465.'),
         required=False,
         widget=forms.CheckboxInput(attrs={
-            'data-display-dependency': '#id_email-email_vendor_1',
+            'data-display-dependency': '#id_email-email_vendor_0',
         }),
     )
     test_email = forms.CharField(

--- a/app/eventyay/static/eventyay-common/js/move-event-email-elements.js
+++ b/app/eventyay/static/eventyay-common/js/move-event-email-elements.js
@@ -1,12 +1,12 @@
 document.addEventListener('DOMContentLoaded', () => {
-    moveElement('email-send_grid_api_key', 'email-email_vendor', 0)
+    moveElement('email-send_grid_api_key', 'email-email_vendor', 1)
     moveGmailPanel('email-email_vendor', 2)
-    moveElement('email-smtp_host', 'email-email_vendor', 1)
-    moveElement('email-smtp_port', 'email-email_vendor', 1)
-    moveElement('email-smtp_username', 'email-email_vendor', 1)
-    moveElement('email-smtp_password', 'email-email_vendor', 1)
-    moveElement('email-smtp_use_tls', 'email-email_vendor', 1)
-    moveElement('email-smtp_use_ssl', 'email-email_vendor', 1)
+    moveElement('email-smtp_host', 'email-email_vendor', 0)
+    moveElement('email-smtp_port', 'email-email_vendor', 0)
+    moveElement('email-smtp_username', 'email-email_vendor', 0)
+    moveElement('email-smtp_password', 'email-email_vendor', 0)
+    moveElement('email-smtp_use_tls', 'email-email_vendor', 0)
+    moveElement('email-smtp_use_ssl', 'email-email_vendor', 0)
 
     function toggleGmailPanel() {
         const selected = document.querySelector('input[name="email-email_vendor"]:checked')
@@ -66,4 +66,3 @@ function moveGmailPanel(target, targetPos) {
         console.error('move-event-email-elements', e)
     }
 }
-

--- a/app/tests/eventyay_common/test_event_settings_email.py
+++ b/app/tests/eventyay_common/test_event_settings_email.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+import pytest
+
+from eventyay.orga.forms.email import CentralMailSettingsForm
+
+
+@pytest.mark.django_db
+def test_event_email_gateway_vendor_mappings(event):
+    form = CentralMailSettingsForm(obj=event, attribute_name='settings', prefix='email')
+
+    assert [value for value, _label in form.fields['email_vendor'].choices] == [
+        'smtp',
+        'sendgrid',
+        'gmail_api',
+    ]
+    assert form.fields['send_grid_api_key'].widget.attrs['data-display-dependency'] == (
+        '#id_email-email_vendor_1'
+    )
+    for field_name in (
+        'smtp_host',
+        'smtp_port',
+        'smtp_username',
+        'smtp_password',
+        'smtp_use_tls',
+        'smtp_use_ssl',
+    ):
+        assert form.fields[field_name].widget.attrs['data-display-dependency'] == (
+            '#id_email-email_vendor_0'
+        )
+
+    script_path = (
+        Path(__file__).parents[2]
+        / 'eventyay'
+        / 'static'
+        / 'eventyay-common'
+        / 'js'
+        / 'move-event-email-elements.js'
+    )
+    script = script_path.read_text(encoding='utf-8')
+
+    assert "moveElement('email-send_grid_api_key', 'email-email_vendor', 1)" in script
+    for field_name in (
+        'smtp_host',
+        'smtp_port',
+        'smtp_username',
+        'smtp_password',
+        'smtp_use_tls',
+        'smtp_use_ssl',
+    ):
+        assert f"moveElement('email-{field_name}', 'email-email_vendor', 0)" in script
+    assert "moveGmailPanel('email-email_vendor', 2)" in script


### PR DESCRIPTION
Description
 Fixes the email gateway radio button dependencies in the central mail settings form.

 Changes
- Corrected the SendGrid API key field dependency.
- Corrected the SMTP settings dependency.
- Added a regression test for the email gateway vendor mappings.

Fixes #5287

## Summary by Sourcery

Correct email gateway vendor mappings so the central mail settings form displays SendGrid and SMTP options under the right radio buttons.

Bug Fixes:
- Correct the email gateway form dependencies so SendGrid fields and SMTP fields appear under the appropriate vendor selections.

Tests:
- Add regression coverage for email gateway vendor ordering and the corresponding form and JavaScript field mappings.