### PR TITLE
fix: Radio button selection behavior inconsistent in Email Gateway settings

### DIFF
--- a/app/eventyay/orga/forms/email.py
+++ b/app/eventyay/orga/forms/email.py
@@ -76,19 +76,12 @@ class CentralMailSettingsForm(SettingsForm):
         required=False,
         initial='smtp',
     )
-    send_grid_api_key = SecretKeySettingsField(
-        label=_('SendGrid API key'),
-        required=False,
-        widget=SecretKeySettingsWidget(attrs={
-            'data-display-dependency': '#id_email-email_vendor_0',
-        }),
-    )
     smtp_host = forms.CharField(
         label=_('SMTP hostname'),
         required=False,
         widget=forms.TextInput(attrs={
             'placeholder': 'mail.example.org',
-            'data-display-dependency': '#id_email-email_vendor_1',
+            'data-display-dependency': '#id_email-email_vendor_0',
         }),
     )
     smtp_port = forms.IntegerField(
@@ -96,7 +89,7 @@ class CentralMailSettingsForm(SettingsForm):
         required=False,
         widget=forms.TextInput(attrs={
             'placeholder': 'e.g. 587, 465, 25 …',
-            'data-display-dependency': '#id_email-email_vendor_1',
+            'data-display-dependency': '#id_email-email_vendor_0',
         }),
     )
     smtp_username = forms.CharField(
@@ -104,14 +97,14 @@ class CentralMailSettingsForm(SettingsForm):
         required=False,
         widget=forms.TextInput(attrs={
             'placeholder': 'myuser@example.org',
-            'data-display-dependency': '#id_email-email_vendor_1',
+            'data-display-dependency': '#id_email-email_vendor_0',
         }),
     )
     smtp_password = SecretKeySettingsField(
         label=_('SMTP password'),
         required=False,
         widget=SecretKeySettingsWidget(attrs={
-            'data-display-dependency': '#id_email-email_vendor_1',
+            'data-display-dependency': '#id_email-email_vendor_0',
         }),
     )
     smtp_use_tls = forms.BooleanField(
@@ -119,7 +112,7 @@ class CentralMailSettingsForm(SettingsForm):
         help_text=_('Commonly enabled on port 587.'),
         required=False,
         widget=forms.CheckboxInput(attrs={
-            'data-display-dependency': '#id_email-email_vendor_1',
+            'data-display-dependency': '#id_email-email_vendor_0',
         }),
     )
     smtp_use_ssl = forms.BooleanField(
@@ -127,6 +120,13 @@ class CentralMailSettingsForm(SettingsForm):
         help_text=_('Commonly enabled on port 465.'),
         required=False,
         widget=forms.CheckboxInput(attrs={
+            'data-display-dependency': '#id_email-email_vendor_0',
+        }),
+    )
+    send_grid_api_key = SecretKeySettingsField(
+        label=_('SendGrid API key'),
+        required=False,
+        widget=SecretKeySettingsWidget(attrs={
             'data-display-dependency': '#id_email-email_vendor_1',
         }),
     )

--- a/app/eventyay/static/eventyay-common/js/move-event-email-elements.js
+++ b/app/eventyay/static/eventyay-common/js/move-event-email-elements.js
@@ -1,12 +1,12 @@
 document.addEventListener('DOMContentLoaded', () => {
-    moveElement('email-send_grid_api_key', 'email-email_vendor', 0)
+    moveElement('email-send_grid_api_key', 'email-email_vendor', 1)
     moveGmailPanel('email-email_vendor', 2)
-    moveElement('email-smtp_host', 'email-email_vendor', 1)
-    moveElement('email-smtp_port', 'email-email_vendor', 1)
-    moveElement('email-smtp_username', 'email-email_vendor', 1)
-    moveElement('email-smtp_password', 'email-email_vendor', 1)
-    moveElement('email-smtp_use_tls', 'email-email_vendor', 1)
-    moveElement('email-smtp_use_ssl', 'email-email_vendor', 1)
+    moveElement('email-smtp_host', 'email-email_vendor', 0)
+    moveElement('email-smtp_port', 'email-email_vendor', 0)
+    moveElement('email-smtp_username', 'email-email_vendor', 0)
+    moveElement('email-smtp_password', 'email-email_vendor', 0)
+    moveElement('email-smtp_use_tls', 'email-email_vendor', 0)
+    moveElement('email-smtp_use_ssl', 'email-email_vendor', 0)
 
     function toggleGmailPanel() {
         const selected = document.querySelector('input[name="email-email_vendor"]:checked')


### PR DESCRIPTION
### Description
This PR resolves issue #5287 where selecting a custom email gateway type (SMTP server, SendGrid, Gmail/Google Workspace) resulted in erratic UI behavior, such as incorrect fields showing under the wrong options.

### Cause
The root cause was two misconfigurations between the `CentralMailSettingsForm` (`app/eventyay/orga/forms/email.py`) and its associated DOM manipulation script (`app/eventyay/static/eventyay-common/js/move-event-email-elements.js`). In both locations, the index for SMTP (`0`) and SendGrid (`1`) were swapped.

### Fix
- Updated `CentralMailSettingsForm` in `email.py`: `send_grid_api_key` now correctly depends on `#id_email-email_vendor_1`, and `smtp_*` fields correctly depend on `#id_email-email_vendor_0`. 
- Updated `move-event-email-elements.js` so that `moveElement` correctly places `send_grid_api_key` under `targetPos` `1` (SendGrid) and all `smtp_*` fields under `targetPos` `0` (SMTP Server).
- Adjusted the field declaration order in `email.py` for clarity.

### Related Issues
Fixes #5287

## Summary by Sourcery

Fix inconsistent email gateway radio-button behavior by correctly associating settings fields with SMTP and SendGrid options.

Bug Fixes:
- Correct email gateway settings so SMTP fields appear only for SMTP Server and the SendGrid API key appears only for SendGrid.

Enhancements:
- Align backend field dependencies and frontend field placement with the email gateway option ordering.