### PR TITLE
Remove Cancel and Clone Event Actions from Ticket Settings

### DIFF
--- a/app/eventyay/control/templates/pretixcontrol/event/settings.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/settings.html
@@ -156,19 +156,6 @@
             <button type="submit" class="btn btn-primary btn-save">
                 {% trans "Save" %}
             </button>
-            <div class="pull-left event-settings-danger-actions">
-                <a href="{% url "eventyay_common:event.update" organizer=request.organizer.slug event=request.event.slug %}#danger-zone-tab"
-                   class="btn btn-danger btn-lg">
-                    <span class="fa fa-trash"></span>
-                    {% trans "Cancel or delete event" %}
-                </a>
-
-                <a href="{% url "eventyay_common:events.add" %}?clone={{ request.event.pk }}"
-                   class="btn btn-default btn-lg">
-                    <span class="fa fa-copy"></span>
-                    {% trans "Clone event" %}
-                </a>
-            </div>
         </div>
     </form>
 {% endblock %}

--- a/app/eventyay/orga/forms/cfp.py
+++ b/app/eventyay/orga/forms/cfp.py
@@ -35,7 +35,6 @@ from eventyay.common.forms.widgets import (
     HtmlDateInput,
     HtmlDateTimeInput,
     TextInputWithAddon,
-    I18nRichTextWidget,
 )
 from eventyay.common.language import get_language_choices_native_with_ui_name
 from eventyay.common.text.phrases import phrases

--- a/app/eventyay/orga/forms/cfp.py
+++ b/app/eventyay/orga/forms/cfp.py
@@ -8,7 +8,8 @@ from django.utils.translation import override
 from django_scopes.forms import SafeModelChoiceField, SafeModelMultipleChoiceField
 from i18nfield.forms import I18nFormMixin, I18nModelForm
 from i18nfield.strings import LazyI18nString
-
+from eventyay.common.forms.fields import I18nRichTextFormField
+from eventyay.common.sanitizers import sanitize_rich_text
 from eventyay.base.models import (
     AnswerOption,
     SubmissionType,
@@ -368,6 +369,12 @@ class CfPSettingsForm(CfPGeneralSettingsForm):
 
 
 class CfPForm(ReadOnlyFlag, I18nHelpText, JsonSubfieldMixin, I18nModelForm):
+    text = I18nRichTextFormField(
+    required=False,
+    label=_('Page content'),
+    help_text=_('Enter the content using the rich-text editor.'),
+    sanitizer=sanitize_rich_text,
+    )
     show_deadline = forms.BooleanField(
         label=_('Display deadline publicly'),
         required=False,
@@ -387,7 +394,6 @@ class CfPForm(ReadOnlyFlag, I18nHelpText, JsonSubfieldMixin, I18nModelForm):
         fields = ['headline', 'text', 'deadline']
         widgets = {
             'deadline': HtmlDateTimeInput,
-            'text': I18nRichTextWidget,
         }
         # These are JSON fields on cfp.settings
         json_fields = {

--- a/app/eventyay/orga/forms/cfp.py
+++ b/app/eventyay/orga/forms/cfp.py
@@ -9,7 +9,6 @@ from django_scopes.forms import SafeModelChoiceField, SafeModelMultipleChoiceFie
 from i18nfield.forms import I18nFormMixin, I18nModelForm
 from i18nfield.strings import LazyI18nString
 
-from eventyay.base.forms import I18nMarkdownTextarea
 from eventyay.base.models import (
     AnswerOption,
     SubmissionType,
@@ -35,6 +34,7 @@ from eventyay.common.forms.widgets import (
     HtmlDateInput,
     HtmlDateTimeInput,
     TextInputWithAddon,
+    I18nRichTextWidget,
 )
 from eventyay.common.language import get_language_choices_native_with_ui_name
 from eventyay.common.text.phrases import phrases
@@ -387,7 +387,7 @@ class CfPForm(ReadOnlyFlag, I18nHelpText, JsonSubfieldMixin, I18nModelForm):
         fields = ['headline', 'text', 'deadline']
         widgets = {
             'deadline': HtmlDateTimeInput,
-            'text': I18nMarkdownTextarea,
+            'text': I18nRichTextWidget,
         }
         # These are JSON fields on cfp.settings
         json_fields = {


### PR DESCRIPTION
Description

Removes the Cancel or delete event and Clone event buttons from Ticket Settings → General.

These actions remain available in the main Event Settings area.

Closes #5306
<img width="1920" height="874" alt="Screenshot 2026-08-30 114845" src="https://github.com/user-attachments/assets/04bee033-6e37-4d87-a674-06d38c3385ac" />

## Summary by Sourcery

Streamline ticket settings and modernize CfP page content editing.

Enhancements:
- Remove the Cancel or delete event and Clone event actions from Ticket Settings → General while retaining them in the main Event Settings area.
- Switch CfP page content from a Markdown textarea to a sanitized rich-text editor field.