### PR TITLE
feat(admin): group platform data in sidebar

### DIFF
--- a/app/eventyay/control/navigation.py
+++ b/app/eventyay/control/navigation.py
@@ -536,37 +536,42 @@ def get_admin_navigation(request):
         )
     # --------------------------------------------------------------------------
 
+    platform_data_children = [
+        {
+            'label': _('Events'),
+            'url': reverse('eventyay_admin:admin.events'),
+            'active': 'events' in url.url_name,
+        },
+        {
+            'label': _('Organizers'),
+            'url': reverse('eventyay_admin:admin.organizers'),
+            'active': 'organizers' in url.url_name,
+        },
+        {
+            'label': _('Attendees'),
+            'url': reverse('eventyay_admin:admin.attendees'),
+            'active': 'attendees' in url.url_name,
+        },
+        {
+            'label': _('Sessions'),
+            'url': reverse('eventyay_admin:admin.submissions'),
+            'active': 'submissions' in url.url_name,
+        },
+        {
+            'label': _('Orders'),
+            'url': reverse('eventyay_admin:admin.orders'),
+            'active': 'orders' in url.url_name,
+        },
+    ]
+
     nav.extend(
         [
             {
-                'label': _('All Events'),
+                'label': _('Platform Data'),
                 'url': reverse('eventyay_admin:admin.events'),
-                'active': 'events' in url.url_name,
-                'icon': 'calendar',
-            },
-            {
-                'label': _('All Organizers'),
-                'url': reverse('eventyay_admin:admin.organizers'),
-                'active': 'organizers' in url.url_name,
-                'icon': 'group',
-            },
-            {
-                'label': _('All Attendees'),
-                'url': reverse('eventyay_admin:admin.attendees'),
-                'active': 'attendees' in url.url_name,
-                'icon': 'ticket',
-            },
-            {
-                'label': _('All Sessions'),
-                'url': reverse('eventyay_admin:admin.submissions'),
-                'active': 'submissions' in url.url_name,
-                'icon': 'sticky-note-o',
-            },
-            {
-                'label': _('All Orders'),
-                'url': reverse('eventyay_admin:admin.orders'),
-                'active': 'orders' in url.url_name,
-                'icon': 'shopping-cart',
+                'active': any(c['active'] for c in platform_data_children),
+                'icon': 'database',
+                'children': platform_data_children,
             },
             {
                 'label': _('Users'),


### PR DESCRIPTION
Fixes #5314


<img width="5088" height="3364" alt="image" src="https://github.com/user-attachments/assets/f761ccef-48b4-42c1-8dd1-6baa5b30e100" />

## Summary by Sourcery

Organize platform-wide administrative data into a dedicated Platform Data sidebar group.

New Features:
- Group Events, Organizers, Attendees, Sessions, and Orders under a new Platform Data sidebar section.

Enhancements:
- Update sidebar navigation labels and active-state handling for the grouped platform data section.