### PR TITLE
fix(common): extract my orders date filter to external ES module

### DIFF
--- a/app/eventyay/eventyay_common/templates/eventyay_common/orders/orders.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/orders/orders.html
@@ -9,6 +9,7 @@
 
 {% block custom_header %}
     {{ block.super }}
+    <script type="module" src="{% static 'eventyay-common/js/orders-filter.js' %}"></script>
 {% endblock %}
 
 {% block content %}
@@ -96,35 +97,4 @@
         </div>
         {% include 'pretixcontrol/pagination.html' %}
     </div>
-    <script>
-        (function () {
-            var params = new URLSearchParams(window.location.search);
-            ['date_from', 'date_to'].forEach(function (name) {
-                if (!params.get(name)) {
-                    var input = document.querySelector('input[name="' + name + '"]');
-                    if (input) input.value = '';
-                }
-            });
-
-            var fromInput = document.querySelector('input[name="date_from"]');
-            var toInput = document.querySelector('input[name="date_to"]');
-            if (fromInput && toInput) {
-                function syncRangeLimits() {
-                    if (fromInput.value) {
-                        toInput.min = fromInput.value;
-                    } else {
-                        toInput.removeAttribute('min');
-                    }
-                    if (toInput.value) {
-                        fromInput.max = toInput.value;
-                    } else {
-                        fromInput.removeAttribute('max');
-                    }
-                }
-                fromInput.addEventListener('change', syncRangeLimits);
-                toInput.addEventListener('change', syncRangeLimits);
-                syncRangeLimits();
-            }
-        })();
-    </script>
 {% endblock %}

--- a/app/eventyay/static/eventyay-common/js/orders-filter.js
+++ b/app/eventyay/static/eventyay-common/js/orders-filter.js
@@ -1,0 +1,42 @@
+function initOrdersDateFilter() {
+  const params = new URLSearchParams(window.location.search);
+  ['date_from', 'date_to'].forEach((name) => {
+    if (!params.get(name)) {
+      const input = document.querySelector(`input[name="${name}"]`);
+      if (input) {
+        input.value = '';
+      }
+    }
+  });
+
+  const fromInput = document.querySelector('input[name="date_from"]');
+  const toInput = document.querySelector('input[name="date_to"]');
+
+  if (fromInput && toInput) {
+    function syncRangeLimits() {
+      if (fromInput.value) {
+        toInput.min = fromInput.value;
+      } else {
+        toInput.removeAttribute('min');
+      }
+
+      if (toInput.value) {
+        fromInput.max = toInput.value;
+      } else {
+        fromInput.removeAttribute('max');
+      }
+    }
+
+    fromInput.addEventListener('change', syncRangeLimits);
+    toInput.addEventListener('change', syncRangeLimits);
+    syncRangeLimits();
+  }
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initOrdersDateFilter);
+} else {
+  initOrdersDateFilter();
+}
+
+export { initOrdersDateFilter };


### PR DESCRIPTION
### Summary of Changes

* Extracted the inline IIFE script from `orders.html` into a standalone ES module: `app/eventyay/static/eventyay-common/js/orders-filter.js`.
* Loaded the module via `<script type="module">` inside `{% block custom_header %}`.
* Replaced `var` declarations with `const` and added modern DOM ready handling.

### Motivation

* Enforces `.github/instructions/js.instructions.md`, which requires eliminating inline `<script>` tags for Content Security Policy (CSP) compliance and using ES modules instead of IIFEs.
* Preserves the existing behavior while modernizing the script structure.

### Testing

* Verified that `date_from` and `date_to` range synchronization works as expected.
* Verified that stale inputs are cleared when date parameters are omitted from query strings.

## Summary by Sourcery

Move the My Orders date filtering logic out of the template and into a CSP-compatible ES module while preserving its existing behavior.

Bug Fixes:
- Preserve synchronization of the orders date range inputs and clearing of stale query-filter values.

Enhancements:
- Extract the orders date filter behavior into a reusable external ES module and load it from the orders template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order date filtering by clearing empty date values that are not present in the URL.
  * Date range filters now automatically enforce valid minimum and maximum dates based on the selected values.
  * Date constraints update immediately when either date is changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->