### PR TITLE
feat: add eventyay-business plugin to dependencies

### DIFF
--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -105,6 +105,7 @@ dependencies = [
     "eventyay-teamshifts @ git+https://github.com/fossasia/eventyay-teamshifts.git@dev",
     "eventyay-interpretation @ git+https://github.com/fossasia/eventyay-interpretation.git@dev",
     "eventyay-hubspot @ git+https://github.com/fossasia/eventyay-hubspot.git@dev",
+    "eventyay-business @ git+https://github.com/fossasia/eventyay-business.git@main",
     "execnet>=2.1.2",
     "fido2>=2.2.0",
     "fonttools>=4.63.0",

--- a/app/uv.lock
+++ b/app/uv.lock
@@ -1163,6 +1163,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventyay-business"
+version = "1.0.0"
+source = { git = "https://github.com/fossasia/eventyay-business.git?rev=main#d3344e72409fd58481f7870f4c75f4fc474448dd" }
+
+[[package]]
 name = "eventyay-hubspot"
 version = "1.0.0"
 source = { git = "https://github.com/fossasia/eventyay-hubspot.git?rev=dev#c80f2316728ce78dd7aea1130cc235fe17af8e5f" }
@@ -1292,6 +1297,7 @@ dependencies = [
     { name = "emoji" },
     { name = "et-xmlfile" },
     { name = "eventyay-bitpay" },
+    { name = "eventyay-business" },
     { name = "eventyay-hubspot" },
     { name = "eventyay-interpretation" },
     { name = "eventyay-paypal" },
@@ -1532,6 +1538,7 @@ requires-dist = [
     { name = "emoji", specifier = ">=2.15.0" },
     { name = "et-xmlfile", specifier = ">=2.0.0" },
     { name = "eventyay-bitpay", git = "https://github.com/fossasia/eventyay-bitpay.git?rev=main" },
+    { name = "eventyay-business", git = "https://github.com/fossasia/eventyay-business.git?rev=main" },
     { name = "eventyay-hubspot", git = "https://github.com/fossasia/eventyay-hubspot.git?rev=dev" },
     { name = "eventyay-interpretation", git = "https://github.com/fossasia/eventyay-interpretation.git?rev=dev" },
     { name = "eventyay-paypal", git = "https://github.com/fossasia/eventyay-paypal.git?rev=main" },


### PR DESCRIPTION
Adds the eventyay-business plugin to the core dependencies so it installs and runs alongside the platform.

## Summary by Sourcery

Add eventyay-business to the platform dependencies so it is installed alongside the core application.

New Features:
- Add the eventyay-business plugin as a core platform dependency.

Build:
- Update the dependency lockfile to include eventyay-business and its resolved dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added the `eventyay-business` package as a runtime dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->