### PR TITLE
feat: implement Thin Entitlement Kernel for decoupled capability checks

### DIFF
--- a/app/eventyay/base/entitlements.py
+++ b/app/eventyay/base/entitlements.py
@@ -1,0 +1,51 @@
+import logging
+
+from eventyay.base.signals import (
+    entitlement_check,
+    entitlement_usage_recorded,
+    register_entitlements,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def check_entitlement(organizer, capability: str, **kwargs) -> bool:
+    """
+    Checks if an organizer has a specific capability.
+    Dispatches the `entitlement_check` signal.
+    If ANY receiver returns False, access is denied.
+    Otherwise (if no receivers or all return True/None), access is allowed.
+    """
+    responses = entitlement_check.send(sender=organizer, capability=capability, **kwargs)
+    for receiver, response in responses:
+        if response is False:
+            return False
+    return True
+
+
+def record_usage(organizer, capability: str, amount: int = 1, **kwargs) -> None:
+    """
+    Records usage of a capability for an organizer.
+    Dispatches the `entitlement_usage_recorded` signal.
+    """
+    entitlement_usage_recorded.send(
+        sender=organizer, capability=capability, amount=amount, **kwargs
+    )
+
+
+def get_capability_registry() -> dict:
+    """
+    Returns a dictionary of all registered capabilities by dispatching `register_entitlements`.
+    """
+    registry = {}
+    responses = register_entitlements.send(sender=None)
+    for receiver, response in responses:
+        if isinstance(response, dict):
+            registry.update(response)
+        elif response is not None:
+            logger.warning(
+                "Receiver %r for register_entitlements returned %r instead of dict",
+                receiver,
+                type(response),
+            )
+    return registry

--- a/app/eventyay/base/signals.py
+++ b/app/eventyay/base/signals.py
@@ -819,3 +819,25 @@ return a dictionary mapping names of attributes in the settings store to DRF ser
 
 As with all event-plugin signals, the ``sender`` keyword argument will contain the event.
 """
+
+entitlement_check = GlobalSignal()
+"""
+Sent to check if a capability is allowed for an organizer. 
+If any receiver returns False, the capability is denied.
+Sender is an ``Organizer`` instance.
+Kwargs: ``capability`` (str)
+"""
+
+entitlement_usage_recorded = GlobalSignal()
+"""
+Sent to record usage of a specific capability.
+Sender is an ``Organizer`` instance.
+Kwargs: ``capability`` (str), ``amount`` (int)
+"""
+
+register_entitlements = GlobalSignal()
+"""
+Sent to collect all available capabilities. 
+Receivers should return a dictionary of capabilities they define or enforce.
+Sender is None.
+"""

--- a/app/eventyay/base/signals.py
+++ b/app/eventyay/base/signals.py
@@ -820,7 +820,8 @@ return a dictionary mapping names of attributes in the settings store to DRF ser
 As with all event-plugin signals, the ``sender`` keyword argument will contain the event.
 """
 
-entitlement_check = GlobalSignal()
+
+entitlement_check = django.dispatch.Signal()
 """
 Sent to check if a capability is allowed for an organizer. 
 If any receiver returns False, the capability is denied.
@@ -828,14 +829,14 @@ Sender is an ``Organizer`` instance.
 Kwargs: ``capability`` (str)
 """
 
-entitlement_usage_recorded = GlobalSignal()
+entitlement_usage_recorded = django.dispatch.Signal()
 """
 Sent to record usage of a specific capability.
 Sender is an ``Organizer`` instance.
 Kwargs: ``capability`` (str), ``amount`` (int)
 """
 
-register_entitlements = GlobalSignal()
+register_entitlements = django.dispatch.Signal()
 """
 Sent to collect all available capabilities. 
 Receivers should return a dictionary of capabilities they define or enforce.

--- a/app/tests/base/test_entitlements.py
+++ b/app/tests/base/test_entitlements.py
@@ -1,0 +1,87 @@
+import pytest
+from unittest.mock import MagicMock
+
+from eventyay.base.entitlements import (
+    check_entitlement,
+    get_capability_registry,
+    record_usage,
+)
+from eventyay.base.signals import (
+    entitlement_check,
+    entitlement_usage_recorded,
+    register_entitlements,
+)
+
+
+@pytest.fixture
+def dummy_organizer():
+    return MagicMock()
+
+
+@pytest.mark.django_db
+def test_check_entitlement_default_allow(dummy_organizer):
+    """If no receivers block it, it should return True."""
+    assert check_entitlement(dummy_organizer, "some_capability") is True
+
+
+@pytest.mark.django_db
+def test_check_entitlement_denied(dummy_organizer):
+    """If a receiver returns False, it should return False."""
+    
+    def deny_receiver(sender, capability, **kwargs):
+        if capability == "restricted_feature":
+            return False
+        return True
+
+    entitlement_check.connect(deny_receiver)
+    try:
+        assert check_entitlement(dummy_organizer, "restricted_feature") is False
+        assert check_entitlement(dummy_organizer, "other_feature") is True
+    finally:
+        entitlement_check.disconnect(deny_receiver)
+
+
+@pytest.mark.django_db
+def test_record_usage(dummy_organizer):
+    """Test that record_usage dispatches the correct signal."""
+    received = []
+
+    def usage_receiver(sender, capability, amount, **kwargs):
+        received.append((sender, capability, amount))
+
+    entitlement_usage_recorded.connect(usage_receiver)
+    try:
+        record_usage(dummy_organizer, "test_cap", amount=5)
+        assert len(received) == 1
+        assert received[0] == (dummy_organizer, "test_cap", 5)
+    finally:
+        entitlement_usage_recorded.disconnect(usage_receiver)
+
+
+@pytest.mark.django_db
+def test_get_capability_registry():
+    """Test that get_capability_registry merges dictionaries correctly."""
+    
+    def reg_receiver_1(sender, **kwargs):
+        return {"cap1": "Description 1"}
+
+    def reg_receiver_2(sender, **kwargs):
+        return {"cap2": "Description 2"}
+
+    def reg_receiver_invalid(sender, **kwargs):
+        return ["invalid list"]
+
+    register_entitlements.connect(reg_receiver_1)
+    register_entitlements.connect(reg_receiver_2)
+    register_entitlements.connect(reg_receiver_invalid)
+    
+    try:
+        registry = get_capability_registry()
+        assert registry == {
+            "cap1": "Description 1",
+            "cap2": "Description 2",
+        }
+    finally:
+        register_entitlements.disconnect(reg_receiver_1)
+        register_entitlements.disconnect(reg_receiver_2)
+        register_entitlements.disconnect(reg_receiver_invalid)


### PR DESCRIPTION
## What

Introduces a **Thin Entitlement Kernel** in Eventyay core (`eventyay.base.entitlements`). 
This provides a standardized, signal-based API for checking capabilities, recording usage, and registering capabilities without introducing any direct dependencies on business tier models.

### Key Additions
1. **`entitlement_check`**: A `GlobalSignal` dispatched when checking if an organizer is allowed to use a capability. If no receivers block it, the core fails open and returns `True`.
2. **`entitlement_usage_recorded`**: A `GlobalSignal` dispatched to record the usage of a capability for an organizer.
3. **`register_entitlements`**: A `GlobalSignal` that allows plugins to advertise what capabilities they define/enforce.
4. **Helper Functions**: `check_entitlement()`, `record_usage()`, and `get_capability_registry()` wrap the signals to provide a clean API for feature plugins.

## Why

This adheres strictly to the architectural recommendation that Eventyay core should not contain hardcoded `if tier.slug == "plus"` checks or `Organizer.tier` foreign keys. Instead:
- Feature plugins (like Loungemesh or HubSpot) simply call `check_entitlement(organizer, 'hubspot')`.
- The `eventyay-business` plugin (if installed) listens to the `entitlement_check` signal, queries its own tier entitlement models, and returns `False` if the organizer's tier does not include the capability.
- If `eventyay-business` is not installed (e.g., in self-hosted instances), no one answers the signal and `check_entitlement` safely returns `True`, allowing the feature to work without restrictions.

## Summary by Sourcery

Introduce a decoupled entitlement kernel that lets feature plugins integrate capability checks and usage tracking through standardized signals.

New Features:
- Add a signal-based entitlement API for checking capabilities, recording usage, and registering available capabilities without coupling core to business-tier models.

Enhancements:
- Provide fail-open entitlement checks and aggregate capability registrations from connected plugins.

Tests:
- Add coverage for default-allow and denied entitlement checks, usage recording, and capability registry aggregation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added entitlement checks to determine whether capabilities are available.
  - Added usage tracking for capabilities, including usage amounts.
  - Added a capability registry for collecting available entitlements from registered integrations.
  - Added extension points for entitlement decisions, usage recording, and capability registration.

- **Tests**
  - Added coverage for default access, denied capabilities, usage recording, registry merging, and invalid registration responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes fossasia/eventyay-business#7