### PR TITLE
feat: Add generic entitlement provider interface

### DIFF
--- a/app/eventyay/base/entitlements.py
+++ b/app/eventyay/base/entitlements.py
@@ -32,8 +32,7 @@ def check_entitlement(
     Otherwise, returns an EntitlementDecision with allowed=True.
     """
     if not capability:
-        # Graceful fallback if called without a capability, though strictly it should be passed
-        return EntitlementDecision(allowed=True)
+        raise ValueError("Capability cannot be empty when checking entitlements.")
         
     responses = entitlement_check.send(
         sender=organizer, event=event, capability=capability, quantity=quantity, **kwargs

--- a/app/eventyay/base/entitlements.py
+++ b/app/eventyay/base/entitlements.py
@@ -1,4 +1,6 @@
 import logging
+from dataclasses import dataclass
+from typing import Optional
 
 from eventyay.base.signals import (
     entitlement_check,
@@ -9,18 +11,45 @@ from eventyay.base.signals import (
 logger = logging.getLogger(__name__)
 
 
-def check_entitlement(organizer, capability: str, **kwargs) -> bool:
+@dataclass
+class EntitlementDecision:
+    allowed: bool
+    limit: Optional[int] = None
+    used: Optional[int] = None
+    remaining: Optional[int] = None
+    reason_code: Optional[str] = None
+    message: Optional[str] = None
+    upgrade_url: Optional[str] = None
+
+
+def check_entitlement(
+    organizer, event=None, capability: str = "", quantity: int = 1, **kwargs
+) -> EntitlementDecision:
     """
-    Checks if an organizer has a specific capability.
+    Checks if an organizer has a specific capability, accommodating a requested quantity.
     Dispatches the `entitlement_check` signal.
-    If ANY receiver returns False, access is denied.
-    Otherwise (if no receivers or all return True/None), access is allowed.
+    If ANY receiver returns an EntitlementDecision with allowed=False, access is denied.
+    Otherwise, returns an EntitlementDecision with allowed=True.
     """
-    responses = entitlement_check.send(sender=organizer, capability=capability, **kwargs)
+    if not capability:
+        # Graceful fallback if called without a capability, though strictly it should be passed
+        return EntitlementDecision(allowed=True)
+        
+    responses = entitlement_check.send(
+        sender=organizer, event=event, capability=capability, quantity=quantity, **kwargs
+    )
+    
+    final_decision = EntitlementDecision(allowed=True)
+    
     for receiver, response in responses:
-        if response is False:
-            return False
-    return True
+        if isinstance(response, EntitlementDecision):
+            if not response.allowed:
+                return response
+            final_decision = response
+        elif response is False:
+            return EntitlementDecision(allowed=False, reason_code="denied_by_plugin")
+            
+    return final_decision
 
 
 def record_usage(organizer, capability: str, amount: int = 1, **kwargs) -> None:

--- a/app/eventyay/base/entitlements.py
+++ b/app/eventyay/base/entitlements.py
@@ -1,0 +1,51 @@
+import logging
+
+from eventyay.base.signals import (
+    entitlement_check,
+    entitlement_usage_recorded,
+    register_entitlements,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def check_entitlement(organizer, capability: str, **kwargs) -> bool:
+    """
+    Checks if an organizer has a specific capability.
+    Dispatches the `entitlement_check` signal.
+    If ANY receiver returns False, access is denied.
+    Otherwise (if no receivers or all return True/None), access is allowed.
+    """
+    responses = entitlement_check.send(sender=organizer, capability=capability, **kwargs)
+    for receiver, response in responses:
+        if response is False:
+            return False
+    return True
+
+
+def record_usage(organizer, capability: str, amount: int = 1, **kwargs) -> None:
+    """
+    Records usage of a capability for an organizer.
+    Dispatches the `entitlement_usage_recorded` signal.
+    """
+    entitlement_usage_recorded.send(
+        sender=organizer, capability=capability, amount=amount, **kwargs
+    )
+
+
+def get_capability_registry() -> dict:
+    """
+    Returns a dictionary of all registered capabilities by dispatching `register_entitlements`.
+    """
+    registry = {}
+    responses = register_entitlements.send(sender=None)
+    for receiver, response in responses:
+        if isinstance(response, dict):
+            registry.update(response)
+        elif response is not None:
+            logger.warning(
+                "Receiver %r for register_entitlements returned %r instead of dict",
+                receiver,
+                type(response),
+            )
+    return registry

--- a/app/eventyay/base/entitlements.py
+++ b/app/eventyay/base/entitlements.py
@@ -23,7 +23,7 @@ class EntitlementDecision:
 
 
 def check_entitlement(
-    organizer, event=None, capability: str = "", quantity: int = 1, **kwargs
+    organizer, capability: str, event=None, quantity: int = 1, **kwargs
 ) -> EntitlementDecision:
     """
     Checks if an organizer has a specific capability, accommodating a requested quantity.

--- a/app/eventyay/base/signals.py
+++ b/app/eventyay/base/signals.py
@@ -823,10 +823,10 @@ As with all event-plugin signals, the ``sender`` keyword argument will contain t
 
 entitlement_check = django.dispatch.Signal()
 """
-Sent to check if a capability is allowed for an organizer. 
-If any receiver returns False, the capability is denied.
+Sent to check if a capability is allowed for an organizer.
 Sender is an ``Organizer`` instance.
-Kwargs: ``capability`` (str)
+Kwargs: ``capability`` (str), ``event`` (Event or None), ``quantity`` (int).
+Receivers must accept **kwargs and return an ``EntitlementDecision`` object or a boolean.
 """
 
 entitlement_usage_recorded = django.dispatch.Signal()

--- a/app/eventyay/base/signals.py
+++ b/app/eventyay/base/signals.py
@@ -819,3 +819,25 @@ return a dictionary mapping names of attributes in the settings store to DRF ser
 
 As with all event-plugin signals, the ``sender`` keyword argument will contain the event.
 """
+
+entitlement_check = GlobalSignal()
+"""
+Sent to check if a capability is allowed for an organizer. 
+If any receiver returns False, the capability is denied.
+Sender is an ``Organizer`` instance.
+Kwargs: ``capability`` (str)
+"""
+
+entitlement_usage_recorded = GlobalSignal()
+"""
+Sent to record usage of a specific capability.
+Sender is an ``Organizer`` instance.
+Kwargs: ``capability`` (str), ``amount`` (int)
+"""
+
+register_entitlements = GlobalSignal()
+"""
+Sent to collect all available capabilities. 
+Receivers should return a dictionary of capabilities they define or enforce.
+Sender is None.
+"""

--- a/app/eventyay/base/signals.py
+++ b/app/eventyay/base/signals.py
@@ -820,7 +820,8 @@ return a dictionary mapping names of attributes in the settings store to DRF ser
 As with all event-plugin signals, the ``sender`` keyword argument will contain the event.
 """
 
-entitlement_check = GlobalSignal()
+
+entitlement_check = django.dispatch.Signal()
 """
 Sent to check if a capability is allowed for an organizer. 
 If any receiver returns False, the capability is denied.
@@ -828,14 +829,14 @@ Sender is an ``Organizer`` instance.
 Kwargs: ``capability`` (str)
 """
 
-entitlement_usage_recorded = GlobalSignal()
+entitlement_usage_recorded = django.dispatch.Signal()
 """
 Sent to record usage of a specific capability.
 Sender is an ``Organizer`` instance.
 Kwargs: ``capability`` (str), ``amount`` (int)
 """
 
-register_entitlements = GlobalSignal()
+register_entitlements = django.dispatch.Signal()
 """
 Sent to collect all available capabilities. 
 Receivers should return a dictionary of capabilities they define or enforce.

--- a/app/tests/base/test_entitlements.py
+++ b/app/tests/base/test_entitlements.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import MagicMock
 
 from eventyay.base.entitlements import (
+    EntitlementDecision,
     check_entitlement,
     get_capability_registry,
     record_usage,
@@ -20,13 +21,14 @@ def dummy_organizer():
 
 @pytest.mark.django_db
 def test_check_entitlement_default_allow(dummy_organizer):
-    """If no receivers block it, it should return True."""
-    assert check_entitlement(dummy_organizer, "some_capability") is True
+    """If no receivers block it, it should return an allowed decision."""
+    decision = check_entitlement(dummy_organizer, capability="some_capability")
+    assert decision.allowed is True
 
 
 @pytest.mark.django_db
-def test_check_entitlement_denied(dummy_organizer):
-    """If a receiver returns False, it should return False."""
+def test_check_entitlement_denied_bool(dummy_organizer):
+    """If a receiver returns False, it should return a denied decision (legacy fallback)."""
     
     def deny_receiver(sender, capability, **kwargs):
         if capability == "restricted_feature":
@@ -35,8 +37,37 @@ def test_check_entitlement_denied(dummy_organizer):
 
     entitlement_check.connect(deny_receiver)
     try:
-        assert check_entitlement(dummy_organizer, "restricted_feature") is False
-        assert check_entitlement(dummy_organizer, "other_feature") is True
+        decision_denied = check_entitlement(dummy_organizer, capability="restricted_feature")
+        assert decision_denied.allowed is False
+        assert decision_denied.reason_code == "denied_by_plugin"
+        
+        decision_allowed = check_entitlement(dummy_organizer, capability="other_feature")
+        assert decision_allowed.allowed is True
+    finally:
+        entitlement_check.disconnect(deny_receiver)
+
+
+@pytest.mark.django_db
+def test_check_entitlement_denied_decision(dummy_organizer):
+    """If a receiver returns a denied EntitlementDecision, it should return that decision."""
+    
+    def deny_receiver(sender, capability, **kwargs):
+        if capability == "restricted_feature":
+            return EntitlementDecision(allowed=False, reason_code="limit_reached", limit=10, used=10)
+        return EntitlementDecision(allowed=True, limit=10, used=5)
+
+    entitlement_check.connect(deny_receiver)
+    try:
+        decision_denied = check_entitlement(dummy_organizer, capability="restricted_feature")
+        assert decision_denied.allowed is False
+        assert decision_denied.reason_code == "limit_reached"
+        assert decision_denied.limit == 10
+        assert decision_denied.used == 10
+        
+        decision_allowed = check_entitlement(dummy_organizer, capability="other_feature")
+        assert decision_allowed.allowed is True
+        assert decision_allowed.limit == 10
+        assert decision_allowed.used == 5
     finally:
         entitlement_check.disconnect(deny_receiver)
 

--- a/app/tests/base/test_entitlements.py
+++ b/app/tests/base/test_entitlements.py
@@ -116,3 +116,9 @@ def test_get_capability_registry():
         register_entitlements.disconnect(reg_receiver_1)
         register_entitlements.disconnect(reg_receiver_2)
         register_entitlements.disconnect(reg_receiver_invalid)
+
+@pytest.mark.django_db
+def test_check_entitlement_empty_capability(dummy_organizer):
+    """Empty capabilities should raise ValueError to prevent fail-open security bypass."""
+    with pytest.raises(ValueError, match="Capability cannot be empty"):
+        check_entitlement(dummy_organizer, capability="")

--- a/app/tests/base/test_entitlements.py
+++ b/app/tests/base/test_entitlements.py
@@ -1,0 +1,87 @@
+import pytest
+from unittest.mock import MagicMock
+
+from eventyay.base.entitlements import (
+    check_entitlement,
+    get_capability_registry,
+    record_usage,
+)
+from eventyay.base.signals import (
+    entitlement_check,
+    entitlement_usage_recorded,
+    register_entitlements,
+)
+
+
+@pytest.fixture
+def dummy_organizer():
+    return MagicMock()
+
+
+@pytest.mark.django_db
+def test_check_entitlement_default_allow(dummy_organizer):
+    """If no receivers block it, it should return True."""
+    assert check_entitlement(dummy_organizer, "some_capability") is True
+
+
+@pytest.mark.django_db
+def test_check_entitlement_denied(dummy_organizer):
+    """If a receiver returns False, it should return False."""
+    
+    def deny_receiver(sender, capability, **kwargs):
+        if capability == "restricted_feature":
+            return False
+        return True
+
+    entitlement_check.connect(deny_receiver)
+    try:
+        assert check_entitlement(dummy_organizer, "restricted_feature") is False
+        assert check_entitlement(dummy_organizer, "other_feature") is True
+    finally:
+        entitlement_check.disconnect(deny_receiver)
+
+
+@pytest.mark.django_db
+def test_record_usage(dummy_organizer):
+    """Test that record_usage dispatches the correct signal."""
+    received = []
+
+    def usage_receiver(sender, capability, amount, **kwargs):
+        received.append((sender, capability, amount))
+
+    entitlement_usage_recorded.connect(usage_receiver)
+    try:
+        record_usage(dummy_organizer, "test_cap", amount=5)
+        assert len(received) == 1
+        assert received[0] == (dummy_organizer, "test_cap", 5)
+    finally:
+        entitlement_usage_recorded.disconnect(usage_receiver)
+
+
+@pytest.mark.django_db
+def test_get_capability_registry():
+    """Test that get_capability_registry merges dictionaries correctly."""
+    
+    def reg_receiver_1(sender, **kwargs):
+        return {"cap1": "Description 1"}
+
+    def reg_receiver_2(sender, **kwargs):
+        return {"cap2": "Description 2"}
+
+    def reg_receiver_invalid(sender, **kwargs):
+        return ["invalid list"]
+
+    register_entitlements.connect(reg_receiver_1)
+    register_entitlements.connect(reg_receiver_2)
+    register_entitlements.connect(reg_receiver_invalid)
+    
+    try:
+        registry = get_capability_registry()
+        assert registry == {
+            "cap1": "Description 1",
+            "cap2": "Description 2",
+        }
+    finally:
+        register_entitlements.disconnect(reg_receiver_1)
+        register_entitlements.disconnect(reg_receiver_2)
+        register_entitlements.disconnect(reg_receiver_invalid)


### PR DESCRIPTION
Fixes fossasia/eventyay-business#7

**⚠️ Depends on #5441 being merged first.** This PR is stacked on top of the entitlement kernel PR.

- Introduces `EntitlementDecision` dataclass in `entitlements.py`
- Refactors `check_entitlement` to support event, capability, quantity
- Returns standardized decision object (allowed, limit, used, remaining, reason_code)
- Implements default allow policy if no plugin restricts access
- Updates corresponding unit tests

## Summary by Sourcery

Standardize entitlement checks around extensible decision objects while retaining backward-compatible plugin responses.

New Features:
- Add a standardized entitlement decision model with access status, usage limits, reasons, and optional upgrade information.
- Support entitlement checks scoped by event and requested quantity.

Bug Fixes:
- Reject empty capability names to prevent fail-open entitlement checks.

Enhancements:
- Preserve default allow behavior while supporting plugin decisions and legacy boolean denials through the entitlement signal.

Documentation:
- Update entitlement signal documentation to describe event, quantity, and supported receiver responses.

Tests:
- Update entitlement tests for decision objects, legacy denials, plugin-provided limits, and empty capabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an entitlement framework for evaluating organizer access to capabilities.
  * Added detailed entitlement decisions, including limits, current usage, remaining capacity, reasons, messages, and upgrade links.
  * Added support for recording capability usage and retrieving registered capability definitions.
  * Added compatibility with both detailed access decisions and simple allow/deny responses.
  * Empty capability requests are now rejected to ensure valid entitlement checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->