### PR TITLE
fix: correct pyproject.toml to discover all eventyay subpackages

### DIFF
--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -289,8 +289,9 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 [tool.ruff.lint.isort]
 lines-after-imports = 2
 
-[tool.setuptools]
-packages = ["eventyay"]
+[tool.setuptools.packages.find]
+include = ["eventyay*"]
+namespaces = false
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "tests.tickets.settings"


### PR DESCRIPTION
Changes `packages = ['eventyay']` to use `packages.find` so that subpackages like `eventyay.base` are correctly included when building wheels and sdists.

Previously, running `pip install` or building a wheel of the core repository would only include the top-level files in `eventyay/`, completely missing nested modules like `eventyay.base`. This caused `ModuleNotFoundError: No module named 'eventyay.base'` when plugins attempted to import core logic after installing the core repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package discovery configuration to automatically include supported application packages during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->