### PR TITLE
fix: Missing 'beta' label on Hubspot plugin

### DIFF
--- a/app/eventyay/base/plugins.py
+++ b/app/eventyay/base/plugins.py
@@ -34,6 +34,7 @@ class PluginType(Enum):
 BETA_PLUGINS: frozenset[str] = frozenset(
     [
         'exhibition',
+        'hubspot',
         'interpretation',
         'socialmedia',
         'teamshifts',

--- a/app/tests/tickets/base/test_plugins.py
+++ b/app/tests/tickets/base/test_plugins.py
@@ -23,6 +23,12 @@ def test_plugin_installed(plugin):
     assert plugin.module in settings.INSTALLED_APPS
 
 
+def test_hubspot_in_beta_plugins():
+    from eventyay.base.plugins import BETA_PLUGINS
+
+    assert 'hubspot' in BETA_PLUGINS
+
+
 class PluginSignalTest(TestCase):
     """
     This test case tests the EventPluginSignal handler


### PR DESCRIPTION
## Closes #5506 

This PR adds the **"BETA"** label in the HubSpot plugin's plugin directory, as the other plugins (like Exhibition, Interpretation, Social Media, and Team Shifts) display this label.




## Photo
<img width="1280" height="588" alt="image" src="https://github.com/user-attachments/assets/1a18e672-b47a-47d8-838d-54023955edb9" />

## Summary by Sourcery

Mark the HubSpot plugin as beta and verify its classification.

Bug Fixes:
- Mark the HubSpot plugin as a beta plugin so its directory entry displays the BETA label.

Tests:
- Add coverage confirming HubSpot is included in the beta plugin set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - HubSpot integration is now marked as a beta feature.

- **Tests**
  - Added coverage confirming HubSpot is included among beta integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->