### PR TITLE
fix(account): stop signup flash naming emails

### DIFF
--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -1320,6 +1320,9 @@ ACCOUNT_USER_MODEL_USERNAME_FIELD = None
 # account_email_verification_sent (not to the login page), so ACCOUNT_SIGNUP_REDIRECT_URL
 # below is only reached when the user is already verified (e.g. social auth signup).
 ACCOUNT_EMAIL_VERIFICATION = 'mandatory'
+# Same HTTP response for taken and unused addresses. The mailbox still
+# gets the existing-account mail from CustomAccountAdapter.
+ACCOUNT_PREVENT_ENUMERATION = True
 # Prefer Jinja2 templates for django-allauth
 ACCOUNT_TEMPLATE_EXTENSION = 'jinja'
 ACCOUNT_ADAPTER = 'eventyay.eventyay_common.adapter.CustomAccountAdapter'

--- a/app/eventyay/eventyay_common/adapter.py
+++ b/app/eventyay/eventyay_common/adapter.py
@@ -9,6 +9,7 @@ from django.contrib import messages
 from django.http import HttpRequest, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.http import url_has_allowed_host_and_scheme
+from django.utils.translation import gettext as _
 from pydantic import ValidationError
 
 from eventyay.base.auth import SPAM_ACCOUNT_ERROR, get_auth_backends
@@ -97,6 +98,30 @@ class CustomAccountAdapter(DefaultAccountAdapter):
             email=email,
             signup=signup,
             redirect_url=redirect_url,
+        )
+
+    def add_message(
+        self,
+        request: HttpRequest,
+        level: int,
+        message_template: str | None = None,
+        message_context: dict | None = None,
+        extra_tags: str = '',
+        message: str | None = None,
+    ) -> None:
+        # allauth's default flash names the address. After signup that banner
+        # is still in the session when the user opens login, so a taken email
+        # and a new email used to look different on that page.
+        if message_template == 'account/messages/email_confirmation_sent.txt':
+            message = str(_('We have sent a confirmation email. Check your inbox to continue.'))
+            message_template = None
+        return super().add_message(
+            request,
+            level,
+            message_template=message_template,
+            message_context=message_context,
+            extra_tags=extra_tags,
+            message=message,
         )
 
     def send_account_already_exists_mail(self, email: str) -> None:

--- a/app/tests/eventyay_common/test_signup_enumeration.py
+++ b/app/tests/eventyay_common/test_signup_enumeration.py
@@ -1,0 +1,68 @@
+"""Signup must not tell the browser whether an email is already registered."""
+
+import pytest
+from allauth.account.models import EmailAddress
+from django.contrib.auth import get_user_model
+from django.contrib.messages import get_messages
+from django.test import Client
+from django.urls import reverse
+
+
+User = get_user_model()
+
+SIGNUP_PASSWORD = 'Testpass1!'
+
+
+def _signup_payload(email: str) -> dict[str, str]:
+    return {
+        'email': email,
+        'password1': SIGNUP_PASSWORD,
+        'password2': SIGNUP_PASSWORD,
+    }
+
+
+def _flash_texts(response) -> list[str]:
+    return [str(message) for message in get_messages(response.wsgi_request)]
+
+
+def _post_signup(client, email: str):
+    return client.post(
+        reverse('account_signup'),
+        _signup_payload(email),
+        follow=False,
+    )
+
+
+@pytest.mark.django_db
+def test_existing_email_signup_uses_the_same_public_path_as_a_new_email(client):
+    taken = 'taken@example.com'
+    user = User.objects.create_user(email=taken, password=SIGNUP_PASSWORD)
+    EmailAddress.objects.create(user=user, email=taken, primary=True, verified=True)
+
+    existing = _post_signup(client, taken)
+    new = _post_signup(Client(), 'new-user@example.com')
+
+    assert existing.status_code == new.status_code == 302
+    assert existing['Location'] == new['Location']
+    assert reverse('account_email_verification_sent') in existing['Location']
+
+
+@pytest.mark.django_db
+def test_signup_flash_does_not_echo_the_submitted_email(client):
+    taken = 'admin@example.com'
+    user = User.objects.create_user(email=taken, password=SIGNUP_PASSWORD)
+    EmailAddress.objects.create(user=user, email=taken, primary=True, verified=True)
+
+    response = _post_signup(client, taken)
+    flashes = _flash_texts(response)
+    joined = ' '.join(flashes)
+
+    assert flashes
+    assert taken not in joined
+    assert 'admin@example.com' not in joined
+
+    login = client.get(reverse('auth.login'))
+    body = login.content.decode('utf-8')
+    assert taken not in body
+    assert 'Confirmation e-mail sent to' not in body
+    assert 'Confirmation email sent to' not in body

--- a/app/tests/eventyay_common/test_signup_enumeration.py
+++ b/app/tests/eventyay_common/test_signup_enumeration.py
@@ -50,19 +50,22 @@ def test_existing_email_signup_uses_the_same_public_path_as_a_new_email(client):
 @pytest.mark.django_db
 def test_signup_flash_does_not_echo_the_submitted_email(client):
     taken = 'admin@example.com'
+    unused = 'new-user@example.com'
     user = User.objects.create_user(email=taken, password=SIGNUP_PASSWORD)
     EmailAddress.objects.create(user=user, email=taken, primary=True, verified=True)
 
-    response = _post_signup(client, taken)
-    flashes = _flash_texts(response)
-    joined = ' '.join(flashes)
+    unused_client = Client()
+    existing_flash = ' '.join(_flash_texts(_post_signup(client, taken)))
+    unused_flash = ' '.join(_flash_texts(_post_signup(unused_client, unused)))
 
-    assert flashes
-    assert taken not in joined
-    assert 'admin@example.com' not in joined
+    assert existing_flash
+    assert unused_flash == existing_flash
+    for text in (existing_flash, unused_flash):
+        assert taken not in text
+        assert unused not in text
 
-    login = client.get(reverse('auth.login'))
-    body = login.content.decode('utf-8')
-    assert taken not in body
-    assert 'Confirmation e-mail sent to' not in body
-    assert 'Confirmation email sent to' not in body
+    for browser, email in ((client, taken), (unused_client, unused)):
+        body = browser.get(reverse('auth.login')).content.decode('utf-8')
+        assert email not in body
+        assert 'Confirmation e-mail sent to' not in body
+        assert 'Confirmation email sent to' not in body

--- a/app/tests/eventyay_common/test_signup_enumeration.py
+++ b/app/tests/eventyay_common/test_signup_enumeration.py
@@ -11,6 +11,8 @@ from django.urls import reverse
 User = get_user_model()
 
 SIGNUP_PASSWORD = 'Testpass1!'
+GENERIC_FLASH = 'We have sent a confirmation email. Check your inbox to continue.'
+VERIFY_PAGE_COPY = 'We have sent an email to you for verification.'
 
 
 def _signup_payload(email: str) -> dict[str, str]:
@@ -55,17 +57,31 @@ def test_signup_flash_does_not_echo_the_submitted_email(client):
     EmailAddress.objects.create(user=user, email=taken, primary=True, verified=True)
 
     unused_client = Client()
-    existing_flash = ' '.join(_flash_texts(_post_signup(client, taken)))
-    unused_flash = ' '.join(_flash_texts(_post_signup(unused_client, unused)))
+    existing = _post_signup(client, taken)
+    unused_resp = _post_signup(unused_client, unused)
+    existing_verify = client.get(existing['Location']).content.decode('utf-8')
+    unused_verify = unused_client.get(unused_resp['Location']).content.decode('utf-8')
+    existing_login = client.get(reverse('auth.login')).content.decode('utf-8')
+    unused_login = unused_client.get(reverse('auth.login')).content.decode('utf-8')
+    existing_flash = ' '.join(_flash_texts(existing))
+    unused_flash = ' '.join(_flash_texts(unused_resp))
 
     assert existing_flash
     assert unused_flash == existing_flash
-    for text in (existing_flash, unused_flash):
+    assert GENERIC_FLASH in existing_flash
+    assert VERIFY_PAGE_COPY in existing_verify
+    assert VERIFY_PAGE_COPY in unused_verify
+    assert GENERIC_FLASH in existing_login
+    assert GENERIC_FLASH in unused_login
+    for text in (
+        existing_flash,
+        unused_flash,
+        existing_verify,
+        unused_verify,
+        existing_login,
+        unused_login,
+    ):
         assert taken not in text
         assert unused not in text
-
-    for browser, email in ((client, taken), (unused_client, unused)):
-        body = browser.get(reverse('auth.login')).content.decode('utf-8')
-        assert email not in body
-        assert 'Confirmation e-mail sent to' not in body
-        assert 'Confirmation email sent to' not in body
+        assert 'Confirmation e-mail sent to' not in text
+        assert 'Confirmation email sent to' not in text


### PR DESCRIPTION
![screenshot](https://raw.githubusercontent.com/HuzaifaAbdulRehman/eventyay/pr-5508-screenshot-asset/pr-5508-login-screenshot.png)

Fixes #4016  Signing up with an address that already has an account still lands on the generic verify page. After that, login showed allauth's flash `Confirmation email sent to admin@example.com`. That is the banner in the report.  `CustomAccountAdapter.add_message` now replaces that template with one line that does not name the address. Taken and unused emails already share the same 302 to `account_email_verification_sent`. I left that path alone. And the mailbox still gets allauth's existing-account mail, with login and reset links, which is what @hongquan asked for.  This does not change a public API.  I ran this on Postgres 16:  ``` EVY_POSTGRES_HOST=127.0.0.1 EVY_POSTGRES_PORT=55432 \ EVY_POSTGRES_USER=eventyay EVY_POSTGRES_PASSWORD=eventyay \ EVY_POSTGRES_DB=eventyay-db GITHUB_WORKFLOW=true \ uv run pytest tests/eventyay_common/test_signup_enumeration.py \   tests/base/test_turnstile.py::TestSignupViewIntegration ```  4 passed. The flash test fails if I stash the adapter change and keep the tests.  ## Summary by Sourcery  Prevent account enumeration through signup confirmation messages while preserving existing-account email delivery.  Bug Fixes: - Prevent signup and subsequent login messages from revealing or echoing the submitted email address. - Keep signup responses and verification messaging indistinguishable for existing and unused email addresses.  Tests: - Add coverage for identical signup redirects, verification pages, and flash messages across existing and new email addresses.  <!-- This is an auto-generated comment: release notes by coderabbit.ai --> ## Summary by CodeRabbit  * **Security**   * Improved signup privacy by providing consistent responses for existing and unused email addresses.   * Confirmation emails continue to be sent for existing accounts without revealing whether an address is registered.   * Signup results no longer disclose whether a submitted email address is already associated with an account.  * **User Experience**   * Updated signup messaging to use a generic confirmation prompt directing users to check their inbox. <!-- end of auto-generated comment: release notes by coderabbit.ai -->