### PR TITLE
refactor: remove Browse events from sidebar

### DIFF
--- a/app/eventyay/eventyay_common/navigation.py
+++ b/app/eventyay/eventyay_common/navigation.py
@@ -29,12 +29,6 @@ def get_global_navigation(request: HttpRequest) -> List[MenuItem]:
         return []
     nav = [
         {
-            'label': _('Browse events'),
-            'url': reverse('presale:index'),
-            'active': False,
-            'icon': 'compass',
-        },
-        {
             'label': _('My Tickets'),
             'url': reverse('eventyay_common:orders'),
             'active': 'orders' in url.url_name,

--- a/app/tests/eventyay_common/test_onboarding_dashboard.py
+++ b/app/tests/eventyay_common/test_onboarding_dashboard.py
@@ -232,7 +232,6 @@ def test_private_events_are_not_recommended(new_user_client, db):
 def test_global_navigation_labels(new_user_client):
     response = new_user_client.get(reverse('eventyay_common:dashboard'))
     content = response.content.decode()
-    assert 'Browse events' in content
     assert 'My Tickets' in content
     assert 'Dashboard' in content
 


### PR DESCRIPTION

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/57ff73a2-931b-4553-a2ed-f28eecda45b8" />

This PR removes the 'Browse events' link from the sidebar navigation as requested.

## Summary by Sourcery

Remove the Browse events link from the global sidebar navigation.

Enhancements:
- Remove the “Browse events” entry from the global sidebar navigation.

Tests:
- Update dashboard navigation tests to reflect the removal of the “Browse events” label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Removed the “Browse events” option from the default global navigation.
  - “My Tickets,” “My Sessions,” and “My Events” navigation options remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->