### PR TITLE
fix(billing): define BILLING_REMINDER_SCHEDULE

### DIFF
--- a/app/eventyay/config/settings.py
+++ b/app/eventyay/config/settings.py
@@ -1564,6 +1564,9 @@ EVENTYAY_OBLIGATORY_2FA = conf.obligatory_2fa
 EVENTYAY_SESSION_TIMEOUT_RELATIVE = 3600 * 3
 EVENTYAY_SESSION_TIMEOUT_ABSOLUTE = 3600 * 12
 
+# Calendar days of the month used for unpaid billing-invoice reminders.
+BILLING_REMINDER_SCHEDULE = [14, 28]
+
 # TODO: The `pdftk` tool should be auto-detected.
 PDFTK = ''
 

--- a/app/tests/eventyay_common/test_billing_reminder_schedule.py
+++ b/app/tests/eventyay_common/test_billing_reminder_schedule.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 import pytest
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
-from django_scopes import scopes_disabled
+from django_scopes import scope
 
 from eventyay.base.models import BillingInvoice, Order
 from eventyay.eventyay_common.tasks import collect_billing_invoice
@@ -26,7 +26,7 @@ def test_collect_billing_invoice_stores_reminder_schedule(event):
     last_month_date = _last_month_start()
     order_time = last_month_date + relativedelta(days=5)
 
-    with scopes_disabled():
+    with scope(organizer=event.organizer, event=event):
         Order.objects.create(
             event=event,
             code='BILL1',

--- a/app/tests/eventyay_common/test_billing_reminder_schedule.py
+++ b/app/tests/eventyay_common/test_billing_reminder_schedule.py
@@ -1,0 +1,45 @@
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+from dateutil.relativedelta import relativedelta
+from django.conf import settings
+from django_scopes import scopes_disabled
+
+from eventyay.base.models import BillingInvoice, Order
+from eventyay.eventyay_common.tasks import collect_billing_invoice
+
+
+def _last_month_start() -> datetime:
+    today = datetime.now(UTC)
+    first_day_of_current_month = today.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    return first_day_of_current_month - relativedelta(months=1)
+
+
+@pytest.mark.django_db
+def test_billing_reminder_schedule_is_defined():
+    assert settings.BILLING_REMINDER_SCHEDULE == [14, 28]
+
+
+@pytest.mark.django_db
+def test_collect_billing_invoice_stores_reminder_schedule(event):
+    last_month_date = _last_month_start()
+    order_time = last_month_date + relativedelta(days=5)
+
+    with scopes_disabled():
+        Order.objects.create(
+            event=event,
+            code='BILL1',
+            status=Order.STATUS_PAID,
+            datetime=order_time,
+            expires=order_time + relativedelta(days=7),
+            total=Decimal('50.00'),
+            locale='en',
+        )
+
+        result = collect_billing_invoice(event, last_month_date, Decimal('2.5'), None)
+
+        invoice = BillingInvoice.objects.get(event=event, monthly_bill=last_month_date)
+
+    assert result.status is True
+    assert invoice.reminder_schedule == [14, 28]


### PR DESCRIPTION
Fixes #5526

`collect_billing_invoice()` reads `settings.BILLING_REMINDER_SCHEDULE` when it builds a BillingInvoice. That name was never set in `config/settings.py`, so the first event with paid orders last month raised AttributeError. `monthly_billing_collect()` only catches DatabaseError, so the rest of the organisers never ran.

I added `BILLING_REMINDER_SCHEDULE = [14, 28]`. Those are the calendar days the reminder task already uses. The shape comes from the model's help_text.

I left the catch block alone. Once the setting exists the crash is gone.

Tests in `tests/eventyay_common/test_billing_reminder_schedule.py` check the setting and that a paid order last month creates an invoice with that schedule. 2 passed on Postgres 16.

## Summary by Sourcery

Define the billing reminder schedule and verify that monthly billing invoice collection stores it correctly.

Bug Fixes:
- Define the billing reminder schedule so monthly invoice collection no longer fails when processing events with paid orders from the previous month.

Tests:
- Add coverage verifying the configured reminder days and their persistence on newly collected billing invoices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Billing invoices now include reminder dates scheduled for the 14th and 28th of the month.
  - Unpaid invoice reminders follow a consistent twice-monthly schedule.

- **Tests**
  - Added coverage confirming the configured reminder dates.
  - Verified that the schedule is applied when billing invoices are created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->