### PR TITLE
fix: keep start page events with talks_testmode=False

### DIFF
--- a/app/eventyay/base/models/event.py
+++ b/app/eventyay/base/models/event.py
@@ -2180,10 +2180,6 @@ class Event(
         (even False) plus any other setting value ``True`` are wrongly dropped.
         Use a same-row NOT EXISTS instead.
         """
-        from django.db.models import Exists, OuterRef
-
-        from eventyay.base.models.event import Event_SettingsStore
-
         return qs.exclude(
             Exists(
                 Event_SettingsStore.objects.filter(

--- a/app/eventyay/base/models/event.py
+++ b/app/eventyay/base/models/event.py
@@ -2171,6 +2171,29 @@ class Event(
     def has_component_testmode(self):
         return bool(self.testmode or self.talks_testmode)
 
+    @staticmethod
+    def without_talks_testmode(qs):
+        """Exclude events whose talks component is in test mode.
+
+        Django's ``.exclude(related__a=x, related__b=y)`` splits into two
+        independent EXISTS checks, so events with a ``talks_testmode`` row
+        (even False) plus any other setting value ``True`` are wrongly dropped.
+        Use a same-row NOT EXISTS instead.
+        """
+        from django.db.models import Exists, OuterRef
+
+        from eventyay.base.models.event import Event_SettingsStore
+
+        return qs.exclude(
+            Exists(
+                Event_SettingsStore.objects.filter(
+                    object_id=OuterRef('pk'),
+                    key='talks_testmode',
+                    value='True',
+                )
+            )
+        )
+
     def user_can_view_tickets(self, user=None, request=None):
         private_tickets = self.private_testmode_tickets_enabled
         if not self.tickets_published and not private_tickets:

--- a/app/eventyay/eventyay_common/onboarding.py
+++ b/app/eventyay/eventyay_common/onboarding.py
@@ -107,15 +107,13 @@ def build_profile_prompt_context(user: User) -> dict[str, Any]:
 
 def _public_upcoming_events_qs():
     today = now().replace(hour=0, minute=0, second=0, microsecond=0)
-    return (
+    return Event.without_talks_testmode(
         Event.objects.select_related('organizer')
         .prefetch_related('_settings_objects', 'cfp')
         .filter(live=True, is_public=True, testmode=False)
         .filter(Q(startpage_visible=True) | Q(startpage_featured=True))
         .filter(Q(date_to__gte=today) | Q(date_to__isnull=True, date_from__gte=today))
-        .exclude(_settings_objects__key='talks_testmode', _settings_objects__value='True')
-        .order_by('-startpage_featured', 'date_from')
-    )
+    ).order_by('-startpage_featured', 'date_from')
 
 
 def _event_date_range(event: Event) -> str:

--- a/app/eventyay/presale/views/startpage.py
+++ b/app/eventyay/presale/views/startpage.py
@@ -74,11 +74,10 @@ class StartPageView(TemplateView):
                 return ctx
 
             today_datetime = timezone.localtime().replace(hour=0, minute=0, second=0, microsecond=0)
-            base_qs = (
+            base_qs = Event.without_talks_testmode(
                 Event.objects.select_related('organizer')
                 .prefetch_related('_settings_objects')
                 .filter(live=True, testmode=False)
-                .exclude(_settings_objects__key='talks_testmode', _settings_objects__value='True')
             )
             future_filter = Q(date_to__gte=today_datetime) | Q(date_to__isnull=True, date_from__gte=today_datetime)
             past_filter = Q(date_to__lt=today_datetime) | Q(date_to__isnull=True, date_from__lt=today_datetime)
@@ -160,16 +159,14 @@ class UpcomingEventsView(PaginationMixin, ListView):
 
     def get_queryset(self):
         today_datetime = timezone.localtime().replace(hour=0, minute=0, second=0, microsecond=0)
-        qs = (
+        qs = Event.without_talks_testmode(
             Event.objects.select_related('organizer')
             .prefetch_related('_settings_objects')
             .filter(live=True, is_public=True)
             .filter(Q(startpage_visible=True) | Q(startpage_featured=True))
             .filter(Q(date_to__gte=today_datetime) | Q(date_to__isnull=True, date_from__gte=today_datetime))
             .filter(testmode=False)
-            .exclude(_settings_objects__key='talks_testmode', _settings_objects__value='True')
-            .order_by('date_from')
-        )
+        ).order_by('date_from')
         if self.request.GET.get('cfp') == 'open':
             qs = qs.filter(Q(cfp__deadline__isnull=True) | Q(cfp__deadline__gte=timezone.now()))
         return qs
@@ -191,17 +188,14 @@ class PastEventsView(PaginationMixin, ListView):
 
     def get_queryset(self):
         today_datetime = timezone.localtime().replace(hour=0, minute=0, second=0, microsecond=0)
-        qs = (
+        return Event.without_talks_testmode(
             Event.objects.select_related('organizer')
             .prefetch_related('_settings_objects')
             .filter(live=True)
             .filter(Q(startpage_visible=True) | Q(startpage_featured=True))
             .filter(Q(date_to__lt=today_datetime) | Q(date_to__isnull=True, date_from__lt=today_datetime))
             .filter(testmode=False)
-            .exclude(_settings_objects__key='talks_testmode', _settings_objects__value='True')
-            .order_by('-date_from')
-        )
-        return qs
+        ).order_by('-date_from')
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
@@ -228,7 +222,7 @@ class FollowedEventsView(TemplateView):
 
         organizer_groups = []
         for org in organizers:
-            events_qs = (
+            events_qs = Event.without_talks_testmode(
                 Event.objects.filter(
                     organizer=org,
                     live=True,
@@ -236,11 +230,9 @@ class FollowedEventsView(TemplateView):
                 .filter(Q(startpage_visible=True) | Q(startpage_featured=True))
                 .filter(Q(date_to__gte=today_datetime) | Q(date_to__isnull=True, date_from__gte=today_datetime))
                 .filter(testmode=False)
-                .exclude(_settings_objects__key='talks_testmode', _settings_objects__value='True')
                 .select_related('organizer')
                 .prefetch_related('_settings_objects')
-                .order_by('date_from')[:9]
-            )
+            ).order_by('date_from')[:9]
             org_events = list(events_qs)
             if org_events:
                 organizer_groups.append({

--- a/app/tests/tickets/presale/test_startpage_optimization.py
+++ b/app/tests/tickets/presale/test_startpage_optimization.py
@@ -94,3 +94,40 @@ def test_startpage_bounded_query_scaling(startpage_events, client, django_assert
     assert len(ctx['past_events']) <= 8
     assert len(ctx['upcoming_events']) <= 8
     assert len(ctx['featured_events']) <= 8
+
+
+@pytest.mark.django_db
+def test_startpage_keeps_featured_when_talks_testmode_false_and_other_true_setting(
+    startpage_events, client
+):
+    """Regression: Django exclude(related__a, related__b) must not drop live events.
+
+    Prod events often have talks_testmode=False stored plus unrelated True settings
+    (plugins). The old exclude wrongly hid them from Featured/Upcoming.
+    """
+    _, e_featured, _, _ = startpage_events
+    with scopes_disabled():
+        e_featured.settings.set('talks_testmode', False)
+        e_featured.settings.set('payment_stripe__enabled', True)
+
+    response = client.get('/')
+    assert response.status_code == 200
+    names = [str(e.name) for e in response.context['featured_events']]
+    assert 'Featured Event' in names
+
+    upcoming = client.get('/upcoming/')
+    assert upcoming.status_code == 200
+    upcoming_names = [str(e.name) for e in upcoming.context['events']]
+    assert 'Featured Event' in upcoming_names
+
+
+@pytest.mark.django_db
+def test_startpage_hides_events_with_talks_testmode_true(startpage_events, client):
+    _, e_featured, _, _ = startpage_events
+    with scopes_disabled():
+        e_featured.settings.set('talks_testmode', True)
+
+    response = client.get('/')
+    assert response.status_code == 200
+    names = [str(e.name) for e in response.context['featured_events']]
+    assert 'Featured Event' not in names


### PR DESCRIPTION
## Summary
- Featured/Upcoming/Past start-page queries used `.exclude(_settings_objects__key='talks_testmode', _settings_objects__value='True')`, which Django compiles as two independent `EXISTS` checks.
- That wrongly hid live events that had a `talks_testmode=False` settings row **and** any other setting with value `True` (common with payments/plugins), e.g. OpenTechSummit India on eventyay.com.
- Replace with a same-row `NOT EXISTS` via `Event.without_talks_testmode()`, and cover the regression in start-page tests.

## Test plan
- [x] `pytest tests/tickets/presale/test_startpage_optimization.py` (5 passed in docker)
- [ ] Reproduce locally: featured event + `talks_testmode=False` + any True setting still appears on `/` and `/upcoming/`
- [ ] Event with `talks_testmode=True` still excluded from start page
- [ ] After deploy, confirm ots2026 appears when Featured/Start page are ON

## Summary by Sourcery

Correct start-page event filtering so only events explicitly using talks test mode are excluded.

Bug Fixes:
- Keep live events with `talks_testmode=False` visible on featured, upcoming, and past start-page listings even when other settings are enabled.
- Continue hiding events whose talks component is explicitly in test mode.

Enhancements:
- Centralize start-page filtering to exclude only events with a matching `talks_testmode=True` setting.
- Add regression coverage for mixed settings and explicit talks test mode behavior.

Tests:
- Add start-page tests covering visibility with mixed settings and exclusion in talks test mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Events with talks test mode enabled are no longer shown in public event listings.
  * Events remain visible when talks test mode is disabled, even if other settings are enabled.
  * Filtering is consistently applied across start pages, upcoming events, past events, and followed events.
  * Event visibility is now handled consistently when multiple event settings are configured.

* **Tests**
  * Added coverage for correct event visibility in featured and upcoming listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->