### PR TITLE
refactor: rename start-page helper to without_testmode

### DIFF
--- a/app/eventyay/base/models/event.py
+++ b/app/eventyay/base/models/event.py
@@ -2172,15 +2172,15 @@ class Event(
         return bool(self.testmode or self.talks_testmode)
 
     @staticmethod
-    def without_testmode(qs):
-        """Exclude events with tickets or talks in test mode.
+    def exclude_talks_testmode(qs):
+        """Exclude events whose talks component is in test mode.
 
         Django's ``.exclude(related__a=x, related__b=y)`` splits into two
         independent EXISTS checks, so events with a ``talks_testmode`` row
         (even False) plus any other setting value ``True`` are wrongly dropped.
-        Use a same-row NOT EXISTS for the talks setting instead.
+        Use a same-row NOT EXISTS instead.
         """
-        return qs.filter(testmode=False).exclude(
+        return qs.exclude(
             Exists(
                 Event_SettingsStore.objects.filter(
                     object_id=OuterRef('pk'),

--- a/app/eventyay/base/models/event.py
+++ b/app/eventyay/base/models/event.py
@@ -2172,15 +2172,15 @@ class Event(
         return bool(self.testmode or self.talks_testmode)
 
     @staticmethod
-    def exclude_talks_testmode(qs):
-        """Exclude events whose talks component is in test mode.
+    def without_testmode(qs):
+        """Exclude events with tickets or talks in test mode.
 
         Django's ``.exclude(related__a=x, related__b=y)`` splits into two
         independent EXISTS checks, so events with a ``talks_testmode`` row
         (even False) plus any other setting value ``True`` are wrongly dropped.
-        Use a same-row NOT EXISTS instead.
+        Use a same-row NOT EXISTS for the talks setting instead.
         """
-        return qs.exclude(
+        return qs.filter(testmode=False).exclude(
             Exists(
                 Event_SettingsStore.objects.filter(
                     object_id=OuterRef('pk'),

--- a/app/eventyay/base/models/event.py
+++ b/app/eventyay/base/models/event.py
@@ -2172,7 +2172,7 @@ class Event(
         return bool(self.testmode or self.talks_testmode)
 
     @staticmethod
-    def without_talks_testmode(qs):
+    def exclude_talks_testmode(qs):
         """Exclude events whose talks component is in test mode.
 
         Django's ``.exclude(related__a=x, related__b=y)`` splits into two

--- a/app/eventyay/eventyay_common/onboarding.py
+++ b/app/eventyay/eventyay_common/onboarding.py
@@ -107,7 +107,7 @@ def build_profile_prompt_context(user: User) -> dict[str, Any]:
 
 def _public_upcoming_events_qs():
     today = now().replace(hour=0, minute=0, second=0, microsecond=0)
-    return Event.without_talks_testmode(
+    return Event.exclude_talks_testmode(
         Event.objects.select_related('organizer')
         .prefetch_related('_settings_objects', 'cfp')
         .filter(live=True, is_public=True, testmode=False)

--- a/app/eventyay/eventyay_common/onboarding.py
+++ b/app/eventyay/eventyay_common/onboarding.py
@@ -107,10 +107,10 @@ def build_profile_prompt_context(user: User) -> dict[str, Any]:
 
 def _public_upcoming_events_qs():
     today = now().replace(hour=0, minute=0, second=0, microsecond=0)
-    return Event.without_testmode(
+    return Event.exclude_talks_testmode(
         Event.objects.select_related('organizer')
         .prefetch_related('_settings_objects', 'cfp')
-        .filter(live=True, is_public=True)
+        .filter(live=True, is_public=True, testmode=False)
         .filter(Q(startpage_visible=True) | Q(startpage_featured=True))
         .filter(Q(date_to__gte=today) | Q(date_to__isnull=True, date_from__gte=today))
     ).order_by('-startpage_featured', 'date_from')

--- a/app/eventyay/eventyay_common/onboarding.py
+++ b/app/eventyay/eventyay_common/onboarding.py
@@ -107,10 +107,10 @@ def build_profile_prompt_context(user: User) -> dict[str, Any]:
 
 def _public_upcoming_events_qs():
     today = now().replace(hour=0, minute=0, second=0, microsecond=0)
-    return Event.exclude_talks_testmode(
+    return Event.without_testmode(
         Event.objects.select_related('organizer')
         .prefetch_related('_settings_objects', 'cfp')
-        .filter(live=True, is_public=True, testmode=False)
+        .filter(live=True, is_public=True)
         .filter(Q(startpage_visible=True) | Q(startpage_featured=True))
         .filter(Q(date_to__gte=today) | Q(date_to__isnull=True, date_from__gte=today))
     ).order_by('-startpage_featured', 'date_from')

--- a/app/eventyay/presale/views/startpage.py
+++ b/app/eventyay/presale/views/startpage.py
@@ -74,10 +74,10 @@ class StartPageView(TemplateView):
                 return ctx
 
             today_datetime = timezone.localtime().replace(hour=0, minute=0, second=0, microsecond=0)
-            base_qs = Event.without_testmode(
+            base_qs = Event.exclude_talks_testmode(
                 Event.objects.select_related('organizer')
                 .prefetch_related('_settings_objects')
-                .filter(live=True)
+                .filter(live=True, testmode=False)
             )
             future_filter = Q(date_to__gte=today_datetime) | Q(date_to__isnull=True, date_from__gte=today_datetime)
             past_filter = Q(date_to__lt=today_datetime) | Q(date_to__isnull=True, date_from__lt=today_datetime)
@@ -159,12 +159,13 @@ class UpcomingEventsView(PaginationMixin, ListView):
 
     def get_queryset(self):
         today_datetime = timezone.localtime().replace(hour=0, minute=0, second=0, microsecond=0)
-        qs = Event.without_testmode(
+        qs = Event.exclude_talks_testmode(
             Event.objects.select_related('organizer')
             .prefetch_related('_settings_objects')
             .filter(live=True, is_public=True)
             .filter(Q(startpage_visible=True) | Q(startpage_featured=True))
             .filter(Q(date_to__gte=today_datetime) | Q(date_to__isnull=True, date_from__gte=today_datetime))
+            .filter(testmode=False)
         ).order_by('date_from')
         if self.request.GET.get('cfp') == 'open':
             qs = qs.filter(Q(cfp__deadline__isnull=True) | Q(cfp__deadline__gte=timezone.now()))
@@ -187,12 +188,13 @@ class PastEventsView(PaginationMixin, ListView):
 
     def get_queryset(self):
         today_datetime = timezone.localtime().replace(hour=0, minute=0, second=0, microsecond=0)
-        return Event.without_testmode(
+        return Event.exclude_talks_testmode(
             Event.objects.select_related('organizer')
             .prefetch_related('_settings_objects')
             .filter(live=True)
             .filter(Q(startpage_visible=True) | Q(startpage_featured=True))
             .filter(Q(date_to__lt=today_datetime) | Q(date_to__isnull=True, date_from__lt=today_datetime))
+            .filter(testmode=False)
         ).order_by('-date_from')
 
     def get_context_data(self, **kwargs):
@@ -220,13 +222,14 @@ class FollowedEventsView(TemplateView):
 
         organizer_groups = []
         for org in organizers:
-            events_qs = Event.without_testmode(
+            events_qs = Event.exclude_talks_testmode(
                 Event.objects.filter(
                     organizer=org,
                     live=True,
                 )
                 .filter(Q(startpage_visible=True) | Q(startpage_featured=True))
                 .filter(Q(date_to__gte=today_datetime) | Q(date_to__isnull=True, date_from__gte=today_datetime))
+                .filter(testmode=False)
                 .select_related('organizer')
                 .prefetch_related('_settings_objects')
             ).order_by('date_from')[:9]

--- a/app/eventyay/presale/views/startpage.py
+++ b/app/eventyay/presale/views/startpage.py
@@ -74,10 +74,10 @@ class StartPageView(TemplateView):
                 return ctx
 
             today_datetime = timezone.localtime().replace(hour=0, minute=0, second=0, microsecond=0)
-            base_qs = Event.exclude_talks_testmode(
+            base_qs = Event.without_testmode(
                 Event.objects.select_related('organizer')
                 .prefetch_related('_settings_objects')
-                .filter(live=True, testmode=False)
+                .filter(live=True)
             )
             future_filter = Q(date_to__gte=today_datetime) | Q(date_to__isnull=True, date_from__gte=today_datetime)
             past_filter = Q(date_to__lt=today_datetime) | Q(date_to__isnull=True, date_from__lt=today_datetime)
@@ -159,13 +159,12 @@ class UpcomingEventsView(PaginationMixin, ListView):
 
     def get_queryset(self):
         today_datetime = timezone.localtime().replace(hour=0, minute=0, second=0, microsecond=0)
-        qs = Event.exclude_talks_testmode(
+        qs = Event.without_testmode(
             Event.objects.select_related('organizer')
             .prefetch_related('_settings_objects')
             .filter(live=True, is_public=True)
             .filter(Q(startpage_visible=True) | Q(startpage_featured=True))
             .filter(Q(date_to__gte=today_datetime) | Q(date_to__isnull=True, date_from__gte=today_datetime))
-            .filter(testmode=False)
         ).order_by('date_from')
         if self.request.GET.get('cfp') == 'open':
             qs = qs.filter(Q(cfp__deadline__isnull=True) | Q(cfp__deadline__gte=timezone.now()))
@@ -188,13 +187,12 @@ class PastEventsView(PaginationMixin, ListView):
 
     def get_queryset(self):
         today_datetime = timezone.localtime().replace(hour=0, minute=0, second=0, microsecond=0)
-        return Event.exclude_talks_testmode(
+        return Event.without_testmode(
             Event.objects.select_related('organizer')
             .prefetch_related('_settings_objects')
             .filter(live=True)
             .filter(Q(startpage_visible=True) | Q(startpage_featured=True))
             .filter(Q(date_to__lt=today_datetime) | Q(date_to__isnull=True, date_from__lt=today_datetime))
-            .filter(testmode=False)
         ).order_by('-date_from')
 
     def get_context_data(self, **kwargs):
@@ -222,14 +220,13 @@ class FollowedEventsView(TemplateView):
 
         organizer_groups = []
         for org in organizers:
-            events_qs = Event.exclude_talks_testmode(
+            events_qs = Event.without_testmode(
                 Event.objects.filter(
                     organizer=org,
                     live=True,
                 )
                 .filter(Q(startpage_visible=True) | Q(startpage_featured=True))
                 .filter(Q(date_to__gte=today_datetime) | Q(date_to__isnull=True, date_from__gte=today_datetime))
-                .filter(testmode=False)
                 .select_related('organizer')
                 .prefetch_related('_settings_objects')
             ).order_by('date_from')[:9]

--- a/app/eventyay/presale/views/startpage.py
+++ b/app/eventyay/presale/views/startpage.py
@@ -74,7 +74,7 @@ class StartPageView(TemplateView):
                 return ctx
 
             today_datetime = timezone.localtime().replace(hour=0, minute=0, second=0, microsecond=0)
-            base_qs = Event.without_talks_testmode(
+            base_qs = Event.exclude_talks_testmode(
                 Event.objects.select_related('organizer')
                 .prefetch_related('_settings_objects')
                 .filter(live=True, testmode=False)
@@ -159,7 +159,7 @@ class UpcomingEventsView(PaginationMixin, ListView):
 
     def get_queryset(self):
         today_datetime = timezone.localtime().replace(hour=0, minute=0, second=0, microsecond=0)
-        qs = Event.without_talks_testmode(
+        qs = Event.exclude_talks_testmode(
             Event.objects.select_related('organizer')
             .prefetch_related('_settings_objects')
             .filter(live=True, is_public=True)
@@ -188,7 +188,7 @@ class PastEventsView(PaginationMixin, ListView):
 
     def get_queryset(self):
         today_datetime = timezone.localtime().replace(hour=0, minute=0, second=0, microsecond=0)
-        return Event.without_talks_testmode(
+        return Event.exclude_talks_testmode(
             Event.objects.select_related('organizer')
             .prefetch_related('_settings_objects')
             .filter(live=True)
@@ -222,7 +222,7 @@ class FollowedEventsView(TemplateView):
 
         organizer_groups = []
         for org in organizers:
-            events_qs = Event.without_talks_testmode(
+            events_qs = Event.exclude_talks_testmode(
                 Event.objects.filter(
                     organizer=org,
                     live=True,


### PR DESCRIPTION
## Summary
- Follow-up to #5534 review: rename the helper to `Event.without_testmode` (no talks/tickets-specific naming).
- Helper now excludes both tickets `testmode` and talks `talks_testmode`, and call sites drop the redundant `testmode=False` filters.

## Test plan
- [ ] Confirm start page / upcoming / past / followed queries still exclude tickets and talks test-mode events
- [ ] `pytest tests/tickets/presale/test_startpage_optimization.py`

## Summary by Sourcery

Enhancements:
- Rename the event query helper to clarify that it excludes talks test-mode events and update all call sites accordingly.