### PR TITLE
fix(orga): reject GET on state-changing views

### DIFF
--- a/app/eventyay/base/models/type.py
+++ b/app/eventyay/base/models/type.py
@@ -71,7 +71,7 @@ class SubmissionType(OrderedModel, PretalxModel):
     class urls(EventUrls):
         """URL patterns for submission type views."""
         base = edit = '{self.event.cfp.urls.types}{self.pk}/'
-        default = '{base}default'
+        default = '{base}default/'
         delete = '{base}delete/'
         prefilled_cfp = '{self.event.cfp.urls.public}?submission_type={self.slug}'
 

--- a/app/eventyay/control/templates/control/event_list.html
+++ b/app/eventyay/control/templates/control/event_list.html
@@ -45,9 +45,12 @@
         </td>
         <td class="text-right video-admin-actions">
             {% if event.domain and event.admin_token %}
-                <a href="{% url 'eventyay_admin:video_admin:event.admin' pk=event.pk %}" class="btn btn-default btn-xs">
-                    <span class="fa fa-lock"></span> {% trans "Admin access" %}
-                </a>
+                <form method="post" action="{% url 'eventyay_admin:video_admin:event.admin' pk=event.pk %}" class="d-inline">
+                    {% csrf_token %}
+                    <button type="submit" class="btn btn-default btn-xs">
+                        <span class="fa fa-lock"></span> {% trans "Admin access" %}
+                    </button>
+                </form>
             {% endif %}
         </td>
         <td class="text-right video-admin-actions">

--- a/app/eventyay/control/templates/pretixcontrol/event/actions.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/actions.html
@@ -7,10 +7,12 @@
         {% for action in actions %}
             <li class="list-group-item logentry">
                 <p>
-                    <a href="{% url "control:event.requiredaction.discard" event=request.event.slug organizer=request.event.organizer.slug id=action.id %}"
-                            class="btn btn-default btn-xs pull-right flip">
-                        {% trans "Hide message" %}
-                    </a>
+                    <form method="post" action="{% url 'control:event.requiredaction.discard' event=request.event.slug organizer=request.event.organizer.slug id=action.id %}" class="pull-right flip">
+                        {% csrf_token %}
+                        <button type="submit" class="btn btn-default btn-xs">
+                            {% trans "Hide message" %}
+                        </button>
+                    </form>
                     <small><span class="fa fa-clock-o"></span> {{ action.datetime|date:"SHORT_DATETIME_FORMAT" }}</small>
                 </p>
                 {{ action.display|safe }}

--- a/app/eventyay/control/templates/pretixcontrol/event/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/index.html
@@ -87,10 +87,12 @@
                 {% for action in actions %}
                     <li class="list-group-item logentry">
                         <p>
-                            <a href="{% url "control:event.requiredaction.discard" event=request.event.slug organizer=request.event.organizer.slug id=action.id %}"
-                               class="btn btn-default btn-xs pull-right flip">
-                                {% trans "Hide message" %}
-                            </a>
+                            <form method="post" action="{% url 'control:event.requiredaction.discard' event=request.event.slug organizer=request.event.organizer.slug id=action.id %}" class="pull-right flip">
+                                {% csrf_token %}
+                                <button type="submit" class="btn btn-default btn-xs">
+                                    {% trans "Hide message" %}
+                                </button>
+                            </form>
                             <small><span
                                     class="fa fa-clock-o"></span> {{ action.datetime|date:"SHORT_DATETIME_FORMAT" }}
                             </small>

--- a/app/eventyay/control/views/admin_views.py
+++ b/app/eventyay/control/views/admin_views.py
@@ -257,6 +257,9 @@ class EventAdminToken(AdministratorPermissionRequiredMixin, DetailView):
             raise Http404("Event not found")
 
     def get(self, request, *args, **kwargs):
+        return self.http_method_not_allowed(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
         event = self.get_object()
 
         # Ensure JWT configuration exists

--- a/app/eventyay/control/views/event.py
+++ b/app/eventyay/control/views/event.py
@@ -1314,12 +1314,12 @@ class EventActions(EventPermissionRequiredMixin, ListView):
 class EventActionDiscard(EventPermissionRequiredMixin, View):
     permission = 'can_change_orders'
 
-    def get(self, request, **kwargs):
+    def post(self, request, **kwargs):
         action = get_object_or_404(RequiredAction, event=request.event, pk=kwargs.get('id'))
         action.done = True
         action.user = request.user
         action.save()
-        messages.success(self.request, _('The issue has been marked as resolved!'))
+        messages.success(request, _('The issue has been marked as resolved!'))
         return redirect(self.get_success_url())
 
     def get_success_url(self) -> str:

--- a/app/eventyay/eventyay_common/templates/eventyay_common/event/index.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/event/index.html
@@ -34,10 +34,13 @@
                 {% for action in actions %}
                     <li class="list-group-item logentry">
                         <p>
-                            {% url "control:event.requiredaction.discard" event=request.event.slug organizer=request.event.organizer.slug id=action.id as discard_url %}
-                            <a href="{{ discard_url }}" class="btn btn-default btn-xs pull-right flip">
-                                {% trans "Hide message" %}
-                            </a>
+                            {% url 'control:event.requiredaction.discard' event=request.event.slug organizer=request.event.organizer.slug id=action.id as discard_url %}
+                            <form method="post" action="{{ discard_url }}" class="pull-right flip">
+                                {% csrf_token %}
+                                <button type="submit" class="btn btn-default btn-xs">
+                                    {% trans "Hide message" %}
+                                </button>
+                            </form>
                             <small><span
                                     class="fa fa-clock-o"></span> {{ action.datetime|date:"SHORT_DATETIME_FORMAT" }}
                             </small>

--- a/app/eventyay/eventyay_common/templates/eventyay_common/event/meetup_dashboard.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/event/meetup_dashboard.html
@@ -33,10 +33,13 @@
                 {% for action in actions %}
                     <li class="list-group-item logentry">
                         <p>
-                            {% url "control:event.requiredaction.discard" event=request.event.slug organizer=request.event.organizer.slug id=action.id as discard_url %}
-                            <a href="{{ discard_url }}" class="btn btn-default btn-xs pull-right flip">
-                                {% trans "Hide message" %}
-                            </a>
+                            {% url 'control:event.requiredaction.discard' event=request.event.slug organizer=request.event.organizer.slug id=action.id as discard_url %}
+                            <form method="post" action="{{ discard_url }}" class="pull-right flip">
+                                {% csrf_token %}
+                                <button type="submit" class="btn btn-default btn-xs">
+                                    {% trans "Hide message" %}
+                                </button>
+                            </form>
                             <small><span
                                     class="fa fa-clock-o"></span> {{ action.datetime|date:"SHORT_DATETIME_FORMAT" }}
                             </small>

--- a/app/eventyay/orga/templates/orga/base.html
+++ b/app/eventyay/orga/templates/orga/base.html
@@ -207,9 +207,12 @@
                 {% blocktranslate with link=link trimmed %}
                     You’re using eventyay as a superuser. This is not recommended.
                 {% endblocktranslate %}
-                <a href="{% url "orga:user.subuser" %}?next={{ request.path|urlencode }}">
-                    {% translate "Please click here to switch to an administrator account." %}
-                </a>
+                <form method="post" action="{% url 'orga:user.subuser' %}?next={{ request.path|urlencode }}" class="d-inline">
+                    {% csrf_token %}
+                    <button type="submit" class="btn btn-link p-0 align-baseline">
+                        {% translate "Please click here to switch to an administrator account." %}
+                    </button>
+                </form>
             </div>
         {% endif %}
         <div id="page-wrapper">

--- a/app/eventyay/orga/templates/orga/cfp/question/_form.html
+++ b/app/eventyay/orga/templates/orga/cfp/question/_form.html
@@ -22,11 +22,10 @@
 {% endblock scripts %}
 
 {% block form %}
+    {% block warnings %}{% endblock warnings %}
     <form method="post" enctype="multipart/form-data">
         {% csrf_token %}
         {% include "common/forms/errors.html" %}
-
-        {% block warnings %}{% endblock warnings %}
 
         {{ form.target.as_field_group }}
         {{ form.variant.as_field_group }}

--- a/app/eventyay/orga/templates/orga/cfp/question/update.html
+++ b/app/eventyay/orga/templates/orga/cfp/question/update.html
@@ -16,11 +16,16 @@
         <span>
             {% if question.active %}
                 {% translate "This field is currently active, it will be asked during submission." %}
-                <a class="btn btn-sm btn-outline-danger"
-                   href="{{ question.urls.toggle }}">{% translate "Hide field" %}</a>
+                <form method="post" action="{{ question.urls.toggle }}" class="d-inline">
+                    {% csrf_token %}
+                    <button type="submit" class="btn btn-sm btn-outline-danger">{% translate "Hide field" %}</button>
+                </form>
             {% else %}
                 {% translate "This field is currently inactive, and will not be asked during submission." %}
-                <a class="btn btn-sm btn-success" href="{{ question.urls.toggle }}">{% translate "Activate field" %}</a>
+                <form method="post" action="{{ question.urls.toggle }}" class="d-inline">
+                    {% csrf_token %}
+                    <button type="submit" class="btn btn-sm btn-success">{% translate "Activate field" %}</button>
+                </form>
             {% endif %}
         </span>
     </div>

--- a/app/eventyay/orga/templates/orga/cfp/submissiontype/list.html
+++ b/app/eventyay/orga/templates/orga/cfp/submissiontype/list.html
@@ -58,11 +58,17 @@
                                 <i class="fa fa-arrows"></i>
                             </button>
                             {% if request.event.cfp.default_type == type %}
-                                <a href="{{ type.urls.default }}" class="btn btn-sm btn-success" title="{% translate 'Click to remove default' %}">
-                                    <i class="fa fa-check"></i> {% translate "Default" %}
-                                </a>
+                                <form method="post" action="{{ type.urls.default }}" class="d-inline">
+                                    {% csrf_token %}
+                                    <button type="submit" class="btn btn-sm btn-success" title="{% translate 'Click to remove default' %}">
+                                        <i class="fa fa-check"></i> {% translate "Default" %}
+                                    </button>
+                                </form>
                             {% else %}
-                                <a href="{{ type.urls.default }}" class="btn btn-sm btn-info">{% translate "Make default" %}</a>
+                                <form method="post" action="{{ type.urls.default }}" class="d-inline">
+                                    {% csrf_token %}
+                                    <button type="submit" class="btn btn-sm btn-info">{% translate "Make default" %}</button>
+                                </form>
                             {% endif %}
                             <a href="{{ type.urls.prefilled_cfp.full }}"
                                title="{% translate "Go to pre-filled CfP form" %}"

--- a/app/eventyay/orga/templates/orga/cfp/talkquestion/_form.html
+++ b/app/eventyay/orga/templates/orga/cfp/talkquestion/_form.html
@@ -24,11 +24,10 @@
 {% endblock scripts %}
 
 {% block form %}
+{% block warnings %}{% endblock warnings %}
 <form method="post" enctype="multipart/form-data">
     {% csrf_token %}
     {% include "common/forms/errors.html" %}
-
-    {% block warnings %}{% endblock warnings %}
 
     {{ form.target.as_field_group }}
     {{ form.variant.as_field_group }}

--- a/app/eventyay/orga/templates/orga/cfp/talkquestion/detail.html
+++ b/app/eventyay/orga/templates/orga/cfp/talkquestion/detail.html
@@ -41,10 +41,16 @@
     <p>
         {% if question.active %}
             {% translate "This field is currently active, it will be asked during submission." %}
-            <a class="btn btn-sm btn-danger" href="{{ question.urls.toggle }}">{% translate "Hide field" %}</a>
+            <form method="post" action="{{ question.urls.toggle }}" class="d-inline">
+                {% csrf_token %}
+                <button type="submit" class="btn btn-sm btn-danger">{% translate "Hide field" %}</button>
+            </form>
         {% else %}
             {% translate "This field is currently inactive, and will not be asked during submission." %}
-            <a class="btn btn-sm btn-success" href="{{ question.urls.toggle }}">{% translate "Activate field" %}</a>
+            <form method="post" action="{{ question.urls.toggle }}" class="d-inline">
+                {% csrf_token %}
+                <button type="submit" class="btn btn-sm btn-success">{% translate "Activate field" %}</button>
+            </form>
         {% endif %}
     </p>
 

--- a/app/eventyay/orga/templates/orga/cfp/talkquestion/update.html
+++ b/app/eventyay/orga/templates/orga/cfp/talkquestion/update.html
@@ -16,11 +16,16 @@
         <span>
             {% if question.active %}
                 {% translate "This field is currently active, it will be asked during submission." %}
-                <a class="btn btn-sm btn-outline-danger"
-                   href="{{ question.urls.toggle }}">{% translate "Hide field" %}</a>
+                <form method="post" action="{{ question.urls.toggle }}" class="d-inline">
+                    {% csrf_token %}
+                    <button type="submit" class="btn btn-sm btn-outline-danger">{% translate "Hide field" %}</button>
+                </form>
             {% else %}
                 {% translate "This field is currently inactive, and will not be asked during submission." %}
-                <a class="btn btn-sm btn-success" href="{{ question.urls.toggle }}">{% translate "Activate field" %}</a>
+                <form method="post" action="{{ question.urls.toggle }}" class="d-inline">
+                    {% csrf_token %}
+                    <button type="submit" class="btn btn-sm btn-success">{% translate "Activate field" %}</button>
+                </form>
             {% endif %}
         </span>
     </div>

--- a/app/eventyay/orga/templates/orga/settings/review.html
+++ b/app/eventyay/orga/templates/orga/settings/review.html
@@ -266,11 +266,14 @@
                                       {% if action != "view" %}
                                           <div class="phase-option-delete flip ml-2 d-flex">
                                               {% if not form.instance.is_active %}
-                                                  <a href="{{ form.instance.urls.activate }}"
-                                                     class="btn btn-outline-warning mr-2 keep-scroll-position"
-                                                     title="{% translate "Activate phase" %}">
-                                                      <i class="fa fa-star"></i>
-                                                  </a>
+                                                  <form method="post" action="{{ form.instance.urls.activate }}" class="d-inline">
+                                                      {% csrf_token %}
+                                                      <button type="submit"
+                                                              class="btn btn-outline-warning mr-2 keep-scroll-position"
+                                                              title="{% translate "Activate phase" %}">
+                                                          <i class="fa fa-star"></i>
+                                                      </button>
+                                                  </form>
                                               {% else %}
                                                   <a href=""
                                                      class="btn btn-warning mr-2 keep-scroll-position"

--- a/app/eventyay/orga/templates/orga/settings/review.html
+++ b/app/eventyay/orga/templates/orga/settings/review.html
@@ -266,14 +266,12 @@
                                       {% if action != "view" %}
                                           <div class="phase-option-delete flip ml-2 d-flex">
                                               {% if not form.instance.is_active %}
-                                                  <form method="post" action="{{ form.instance.urls.activate }}" class="d-inline">
-                                                      {% csrf_token %}
-                                                      <button type="submit"
-                                                              class="btn btn-outline-warning mr-2 keep-scroll-position"
-                                                              title="{% translate "Activate phase" %}">
-                                                          <i class="fa fa-star"></i>
-                                                      </button>
-                                                  </form>
+                                                  <button type="submit"
+                                                          form="activate-phase-{{ form.instance.pk }}"
+                                                          class="btn btn-outline-warning mr-2 keep-scroll-position"
+                                                          title="{% translate "Activate phase" %}">
+                                                      <i class="fa fa-star"></i>
+                                                  </button>
                                               {% else %}
                                                   <a href=""
                                                      class="btn btn-warning mr-2 keep-scroll-position"
@@ -342,4 +340,11 @@
         </section>
         {% include "orga/includes/submit_row.html" %}
     </form>
+    {% for form in phases_formset %}
+        {% if form.instance.pk and not form.instance.is_active %}
+            <form id="activate-phase-{{ form.instance.pk }}" method="post" action="{{ form.instance.urls.activate }}" hidden>
+                {% csrf_token %}
+            </form>
+        {% endif %}
+    {% endfor %}
 {% endblock settings_content %}

--- a/app/eventyay/orga/templates/orga/submission/speakers.html
+++ b/app/eventyay/orga/templates/orga/submission/speakers.html
@@ -111,10 +111,13 @@
                    class="btn btn-info">
                     <i class="fa fa-edit"></i> {{ phrases.base.edit }}
                 </a>
-                <a href="{{ submission.orga_urls.delete_speaker }}?id={{ speaker.user.id }}"
-                   class="btn btn-danger">
-                    <i class="fa fa-trash"></i> {% translate "Remove" %}
-                </a>
+                <form method="post" action="{{ submission.orga_urls.delete_speaker }}" class="d-inline">
+                    {% csrf_token %}
+                    <input type="hidden" name="id" value="{{ speaker.user.id }}">
+                    <button type="submit" class="btn btn-danger">
+                        <i class="fa fa-trash"></i> {% translate "Remove" %}
+                    </button>
+                </form>
             {% endif %}
         </div></div>
     {% endfor %}

--- a/app/eventyay/orga/views/cfp.py
+++ b/app/eventyay/orga/views/cfp.py
@@ -644,31 +644,20 @@ class QuestionView(OrderActionMixin, OrgaCRUDView):
 
 @method_decorator(ensure_csrf_cookie, name='dispatch')
 class CfPQuestionToggle(PermissionRequired, View):
-    """Toggle question field states via AJAX POST or legacy GET."""
+    """Toggle question field states via POST (JSON AJAX or form)."""
 
     permission_required = 'base.update_talkquestion'
 
     def get_object(self) -> TalkQuestion:
         return get_object_or_404(TalkQuestion.all_objects, event=self.request.event, pk=self.kwargs.get('pk'))
 
-    def dispatch(self, request, *args, **kwargs):
-        # Check permissions first
-        if not self.has_permission():
-            return self.handle_no_permission()
-
+    def post(self, request, *args, **kwargs):
         question = self.get_object()
-
-        # Legacy GET: toggle active
-        if request.method == http.HTTPMethod.GET:
-            question.active = not question.active
-            question.save(update_fields=['active'])
-            return redirect(question.urls.base)
-
-        # AJAX POST: toggle specific field
-        if request.method == http.HTTPMethod.POST:
+        if 'application/json' in (request.content_type or ''):
             return self._handle_post(request, question)
-
-        return JsonResponse({'error': 'Method not allowed'}, status=405)
+        question.active = not question.active
+        question.save(update_fields=['active'])
+        return redirect(question.urls.base)
 
     @transaction.atomic
     def _handle_post(self, request, question):
@@ -842,10 +831,9 @@ class SubmissionTypeDefault(PermissionRequired, View):
     def get_object(self):
         return get_object_or_404(self.request.event.submission_types, pk=self.kwargs.get('pk'))
 
-    def dispatch(self, request, *args, **kwargs):
-        super().dispatch(request, *args, **kwargs)
+    def post(self, request, *args, **kwargs):
         submission_type = self.get_object()
-        cfp = self.request.event.cfp
+        cfp = request.event.cfp
 
         if cfp.default_type == submission_type:
             # Already default - remove it
@@ -856,10 +844,10 @@ class SubmissionTypeDefault(PermissionRequired, View):
             # Set as new default
             cfp.default_type = submission_type
             cfp.save(update_fields=['default_type'])
-            submission_type.log_action('eventyay.submission_type.make_default', person=self.request.user, orga=True)
+            submission_type.log_action('eventyay.submission_type.make_default', person=request.user, orga=True)
             messages.success(request, _('The Session Type has been made default.'))
 
-        return redirect(self.request.event.cfp.urls.types)
+        return redirect(request.event.cfp.urls.types)
 
 
 class TrackView(OrderActionMixin, OrgaCRUDView):

--- a/app/eventyay/orga/views/event.py
+++ b/app/eventyay/orga/views/event.py
@@ -299,11 +299,10 @@ class PhaseActivate(EventSettingsPermission, View):
     def get_object(self):
         return get_object_or_404(ReviewPhase, event=self.request.event, pk=self.kwargs.get('pk'))
 
-    def dispatch(self, request, *args, **kwargs):
-        super().dispatch(request, *args, **kwargs)
+    def post(self, request, *args, **kwargs):
         phase = self.get_object()
         phase.activate()
-        return redirect(self.request.event.orga_urls.review_settings)
+        return redirect(request.event.orga_urls.review_settings)
 
 
 class EventMailSettings(EventSettingsPermission, ActionFromUrl, FormView):

--- a/app/eventyay/orga/views/person.py
+++ b/app/eventyay/orga/views/person.py
@@ -97,12 +97,12 @@ class UserSettings(TemplateView):
 
 
 class SubuserView(View):
-    def dispatch(self, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs):
         request.user.is_administrator = request.user.is_superuser
         request.user.is_superuser = False
         request.user.save(update_fields=['is_administrator', 'is_superuser'])
         messages.success(request, _('You are now an administrator instead of a superuser.'))
-        params = request.GET.copy()
+        params = request.POST.copy() if request.POST.get('next') else request.GET.copy()
         url = urllib.parse.unquote(params.pop('next', [''])[0])
         if url and url_has_allowed_host_and_scheme(url, allowed_hosts=None):
             return redirect(url + ('?' + params.urlencode() if params else ''))

--- a/app/eventyay/orga/views/schedule.py
+++ b/app/eventyay/orga/views/schedule.py
@@ -181,10 +181,9 @@ class ScheduleToggleView(EventPermissionRequired, View):
         event.settings.talk_schedule_public = is_public
         event.save(update_fields=['feature_flags'])
 
-    def dispatch(self, request, *args, **kwargs):
-        super().dispatch(request, *args, **kwargs)
-        is_public = not self.request.event.get_feature_flag('show_schedule')
-        self._set_schedule_public(self.request.event, is_public)
+    def post(self, request, *args, **kwargs):
+        is_public = not request.event.get_feature_flag('show_schedule')
+        self._set_schedule_public(request.event, is_public)
         # Trigger tickets to hidden/unhidden schedule menu
         try:
             from eventyay.orga.tasks import trigger_public_schedule
@@ -192,9 +191,9 @@ class ScheduleToggleView(EventPermissionRequired, View):
             trigger_public_schedule.apply_async(
                 kwargs={
                     'is_show_schedule': is_public,
-                    'event_slug': self.request.event.slug,
-                    'organiser_slug': self.request.event.organizer.slug,
-                    'user_email': self.request.user.email,
+                    'event_slug': request.event.slug,
+                    'organiser_slug': request.event.organizer.slug,
+                    'user_email': request.user.email,
                 },
                 ignore_result=True,
             )
@@ -205,7 +204,7 @@ class ScheduleToggleView(EventPermissionRequired, View):
             )
         except Exception as e:
             logger.error('Unexpected error in task: %s', e)
-        return redirect(self.request.event.orga_urls.schedule)
+        return redirect(request.event.orga_urls.schedule)
 
 
 class ScheduleResendMailsView(EventPermissionRequired, View):

--- a/app/eventyay/orga/views/submission.py
+++ b/app/eventyay/orga/views/submission.py
@@ -246,13 +246,12 @@ class SubmissionStateChange(SubmissionViewMixin, FormView):
 class SubmissionSpeakersDelete(SubmissionViewMixin, View):
     permission_required = 'base.update_submission'
 
-    def dispatch(self, request, *args, **kwargs):
-        super().dispatch(request, *args, **kwargs)
+    def post(self, request, *args, **kwargs):
         submission = self.object
-        speaker = get_object_or_404(User, pk=request.GET.get('id'))
+        speaker = get_object_or_404(User, pk=request.POST.get('id') or request.GET.get('id'))
 
         if submission in speaker.submissions.all():
-            submission.remove_speaker(speaker, user=self.request.user)
+            submission.remove_speaker(speaker, user=request.user)
             messages.success(request, _('The speaker has been removed from the proposal.'))
         else:
             messages.warning(request, _('The speaker was not part of this proposal.'))

--- a/app/tests/stable/test_control.py
+++ b/app/tests/stable/test_control.py
@@ -123,6 +123,24 @@ def admin_client(db, staff_client, staff_user):
 
 
 @pytest.mark.django_db
+class TestEventAdminToken:
+    def test_admin_token_rejects_get(self, admin_client, event):
+        response = admin_client.get(f'/admin/video/events/{event.pk}/admin')
+        assert response.status_code == 405
+        event.refresh_from_db()
+        assert not (event.config or {}).get('JWT_secrets')
+
+    def test_admin_token_creates_secret_on_post(self, admin_client, event):
+        from eventyay.base.models.log import LogEntry
+
+        response = admin_client.post(f'/admin/video/events/{event.pk}/admin')
+        assert response.status_code == 302
+        event.refresh_from_db()
+        assert event.config['JWT_secrets']
+        assert LogEntry.objects.filter(action_type='event.adminaccess').exists()
+
+
+@pytest.mark.django_db
 class TestGlobalSettingsEmail:
     """Test global settings email functionality."""
 

--- a/app/tests/talk/orga/views/test_orga_views_cfp.py
+++ b/app/tests/talk/orga/views/test_orga_views_cfp.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import json
+import re
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -10,6 +11,19 @@ from eventyay.base.models import Event
 from eventyay.base.models import QueuedMail
 from eventyay.base.models import TalkQuestion as Question
 from eventyay.base.models.question import TalkQuestionRequired as QuestionRequired
+
+_FORM_OPEN = re.compile(r"<form(?:\s|>)", re.I)
+_FORM_CLOSE = re.compile(r"</form\s*>", re.I)
+
+
+def _max_form_nesting(html: str) -> int:
+    events = [(match.start(), 1) for match in _FORM_OPEN.finditer(html)]
+    events += [(match.start(), -1) for match in _FORM_CLOSE.finditer(html)]
+    depth = max_depth = 0
+    for _, delta in sorted(events):
+        depth += delta
+        max_depth = max(max_depth, depth)
+    return max_depth
 
 
 @pytest.mark.django_db
@@ -629,6 +643,15 @@ def test_can_hide_question_via_json(orga_client, question):
         question = Question.all_objects.get(pk=question.pk)
     assert response.status_code == 200
     assert not question.active
+
+
+@pytest.mark.django_db
+def test_question_edit_toggle_form_is_not_nested(orga_client, question):
+    response = orga_client.get(question.urls.edit)
+    assert response.status_code == 200
+    html = response.content.decode()
+    assert question.urls.toggle in html
+    assert _max_form_nesting(html) <= 1
 
 
 @pytest.mark.django_db

--- a/app/tests/talk/orga/views/test_orga_views_cfp.py
+++ b/app/tests/talk/orga/views/test_orga_views_cfp.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import json
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -105,12 +106,25 @@ def test_make_submission_type_default(
     with scope(event=submission_type.event):
         assert default_submission_type.event.submission_types.count() == 2
         assert submission_type.event.cfp.default_type == default_submission_type
-    response = orga_client.get(submission_type.urls.default, follow=True)
+    response = orga_client.post(submission_type.urls.default, follow=True)
     assert response.status_code == 200
     with scope(event=submission_type.event):
         assert default_submission_type.event.submission_types.count() == 2
         submission_type.event.cfp.refresh_from_db()
         assert submission_type.event.cfp.default_type == submission_type
+
+
+@pytest.mark.django_db
+def test_make_submission_type_default_rejects_get(
+    orga_client, submission_type, default_submission_type
+):
+    with scope(event=submission_type.event):
+        assert submission_type.event.cfp.default_type == default_submission_type
+    response = orga_client.get(submission_type.urls.default)
+    assert response.status_code == 405
+    with scope(event=submission_type.event):
+        submission_type.event.cfp.refresh_from_db()
+        assert submission_type.event.cfp.default_type == default_submission_type
 
 
 @pytest.mark.django_db
@@ -585,7 +599,7 @@ def test_can_remind_answered_submission_question(
 def test_can_hide_question(orga_client, question):
     assert question.active
 
-    response = orga_client.get(question.urls.toggle, follow=True)
+    response = orga_client.post(question.urls.toggle, follow=True)
     with scope(event=question.event):
         question = Question.all_objects.get(pk=question.pk)
 
@@ -594,10 +608,34 @@ def test_can_hide_question(orga_client, question):
 
 
 @pytest.mark.django_db
+def test_hide_question_rejects_get(orga_client, question):
+    assert question.active
+    response = orga_client.get(question.urls.toggle)
+    with scope(event=question.event):
+        question = Question.all_objects.get(pk=question.pk)
+    assert response.status_code == 405
+    assert question.active
+
+
+@pytest.mark.django_db
+def test_can_hide_question_via_json(orga_client, question):
+    assert question.active
+    response = orga_client.post(
+        question.urls.toggle,
+        data=json.dumps({"field": "active", "value": False}),
+        content_type="application/json",
+    )
+    with scope(event=question.event):
+        question = Question.all_objects.get(pk=question.pk)
+    assert response.status_code == 200
+    assert not question.active
+
+
+@pytest.mark.django_db
 def test_can_activate_inactive_question(orga_client, inactive_question):
     assert not inactive_question.active
 
-    response = orga_client.get(inactive_question.urls.toggle, follow=True)
+    response = orga_client.post(inactive_question.urls.toggle, follow=True)
     inactive_question.refresh_from_db()
 
     assert response.status_code == 200

--- a/app/tests/talk/orga/views/test_orga_views_event.py
+++ b/app/tests/talk/orga/views/test_orga_views_event.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import json
+import re
 
 import pytest
 from django.conf import settings
@@ -8,6 +9,19 @@ from django.utils.timezone import now
 from django_scopes import scope
 
 from eventyay.base.models import Event
+
+_FORM_OPEN = re.compile(r"<form(?:\s|>)", re.I)
+_FORM_CLOSE = re.compile(r"</form\s*>", re.I)
+
+
+def _max_form_nesting(html: str) -> int:
+    events = [(match.start(), 1) for match in _FORM_OPEN.finditer(html)]
+    events += [(match.start(), -1) for match in _FORM_CLOSE.finditer(html)]
+    depth = max_depth = 0
+    for _, delta in sorted(events):
+        depth += delta
+        max_depth = max(max_depth, depth)
+    return max_depth
 
 
 def get_settings_form_data(event):
@@ -855,6 +869,21 @@ def test_activate_review_phase_rejects_get(orga_client, event):
     event = Event.objects.get(slug=event.slug)
     with scope(event=event):
         assert event.active_review_phase == phase
+
+
+@pytest.mark.django_db
+def test_review_phase_activate_form_is_not_nested(orga_client, event):
+    with scope(event=event):
+        phase = event.active_review_phase
+        other_phase = event.review_phases.exclude(pk=phase.pk).first()
+        activate_url = other_phase.urls.activate
+        other_pk = other_phase.pk
+    response = orga_client.get(event.orga_urls.review_settings)
+    assert response.status_code == 200
+    html = response.content.decode()
+    assert f'id="activate-phase-{other_pk}"' in html
+    assert activate_url in html
+    assert _max_form_nesting(html) <= 1
 
 
 @pytest.mark.django_db

--- a/app/tests/talk/orga/views/test_orga_views_event.py
+++ b/app/tests/talk/orga/views/test_orga_views_event.py
@@ -838,11 +838,23 @@ def test_edit_review_settings_activate_review_phase(orga_client, event):
         assert event.review_phases.count() == 2
         phase = event.active_review_phase
         other_phase = event.review_phases.exclude(pk=phase.pk).first()
-    response = orga_client.get(other_phase.urls.activate, follow=True)
+    response = orga_client.post(other_phase.urls.activate, follow=True)
     assert response.status_code == 200
     event = Event.objects.get(slug=event.slug)
     with scope(event=event):
         assert event.active_review_phase == other_phase
+
+
+@pytest.mark.django_db
+def test_activate_review_phase_rejects_get(orga_client, event):
+    with scope(event=event):
+        phase = event.active_review_phase
+        other_phase = event.review_phases.exclude(pk=phase.pk).first()
+    response = orga_client.get(other_phase.urls.activate)
+    assert response.status_code == 405
+    event = Event.objects.get(slug=event.slug)
+    with scope(event=event):
+        assert event.active_review_phase == phase
 
 
 @pytest.mark.django_db

--- a/app/tests/talk/orga/views/test_orga_views_person.py
+++ b/app/tests/talk/orga/views/test_orga_views_person.py
@@ -42,7 +42,7 @@ def test_user_typeahead(
 def test_remove_superuser(orga_client, orga_user, follow, expected):
     orga_user.is_superuser = True
     orga_user.save()
-    response = orga_client.get(
+    response = orga_client.post(
         reverse("orga:user.subuser"),
         data={"next": follow},
     )
@@ -55,11 +55,22 @@ def test_remove_superuser(orga_client, orga_user, follow, expected):
 
 @pytest.mark.django_db
 def test_remove_superuser_if_no_superuser(orga_client, orga_user):
-    response = orga_client.get(reverse("orga:user.subuser"), follow=True)
+    response = orga_client.post(reverse("orga:user.subuser"), follow=True)
 
     orga_user.refresh_from_db()
     assert response.status_code == 200
     assert not orga_user.is_superuser
+
+
+@pytest.mark.django_db
+def test_remove_superuser_rejects_get(orga_client, orga_user):
+    orga_user.is_superuser = True
+    orga_user.save()
+    response = orga_client.get(reverse("orga:user.subuser"))
+
+    orga_user.refresh_from_db()
+    assert response.status_code == 405
+    assert orga_user.is_superuser
 
 
 @pytest.mark.django_db

--- a/app/tests/talk/orga/views/test_orga_views_schedule.py
+++ b/app/tests/talk/orga/views/test_orga_views_schedule.py
@@ -377,16 +377,27 @@ def test_orga_can_toggle_schedule_visibility(orga_client, event):
 
     assert event.feature_flags["show_schedule"] is True
 
-    response = orga_client.post(event.orga_urls.toggle_schedule, follow=True)
-    assert response.status_code == 200
+    response = orga_client.post(event.orga_urls.toggle_schedule)
+    assert response.status_code == 302
     event = Event.objects.get(pk=event.pk)
     assert event.feature_flags["show_schedule"] is False
 
-    response = orga_client.post(event.orga_urls.toggle_schedule, follow=True)
-    assert response.status_code == 200
+    response = orga_client.post(event.orga_urls.toggle_schedule)
+    assert response.status_code == 302
     event = Event.objects.get(pk=event.pk)
     with scope(event=event):
         assert event.feature_flags["show_schedule"] is True
+
+
+@pytest.mark.django_db
+def test_toggle_schedule_visibility_rejects_get(orga_client, event):
+    from eventyay.base.models import Event
+
+    assert event.feature_flags["show_schedule"] is True
+    response = orga_client.get(event.orga_urls.toggle_schedule)
+    assert response.status_code == 405
+    event = Event.objects.get(pk=event.pk)
+    assert event.feature_flags["show_schedule"] is True
 
 
 @pytest.mark.django_db

--- a/app/tests/talk/orga/views/test_orga_views_submission.py
+++ b/app/tests/talk/orga/views/test_orga_views_submission.py
@@ -370,10 +370,9 @@ def test_orga_can_readd_speaker(orga_client, submission):
 @pytest.mark.django_db
 def test_orga_can_remove_speaker(orga_client, submission):
     assert submission.speakers.count() == 1
-    response = orga_client.get(
-        submission.orga_urls.delete_speaker
-        + "?id="
-        + str(submission.speakers.first().pk),
+    response = orga_client.post(
+        submission.orga_urls.delete_speaker,
+        data={"id": submission.speakers.first().pk},
         follow=True,
     )
     submission.refresh_from_db()
@@ -384,14 +383,26 @@ def test_orga_can_remove_speaker(orga_client, submission):
 @pytest.mark.django_db
 def test_orga_can_remove_wrong_speaker(orga_client, submission, other_speaker):
     assert submission.speakers.count() == 1
-    response = orga_client.get(
-        submission.orga_urls.delete_speaker + "?id=" + str(other_speaker.pk),
+    response = orga_client.post(
+        submission.orga_urls.delete_speaker,
+        data={"id": other_speaker.pk},
         follow=True,
     )
     submission.refresh_from_db()
     assert response.status_code == 200
     assert submission.speakers.count() == 1
     assert "not part of this proposal" in response.text
+
+
+@pytest.mark.django_db
+def test_orga_remove_speaker_rejects_get(orga_client, submission):
+    speaker_pk = submission.speakers.first().pk
+    response = orga_client.get(
+        submission.orga_urls.delete_speaker + "?id=" + str(speaker_pk)
+    )
+    submission.refresh_from_db()
+    assert response.status_code == 405
+    assert submission.speakers.count() == 1
 
 
 @pytest.mark.django_db

--- a/app/tests/tickets/control/test_events.py
+++ b/app/tests/tickets/control/test_events.py
@@ -1585,6 +1585,32 @@ class EventsTest(SoupTest):
         )
         assert doc.select('.has-error')
 
+    def test_required_action_discard_rejects_get(self):
+        from eventyay.base.models.event import RequiredAction
+
+        self.team1.can_change_orders = True
+        self.team1.save()
+        action = RequiredAction.objects.create(event=self.event1, action_type='test.action')
+        resp = self.client.get(
+            '/control/event/%s/%s/requiredactions/%s/discard' % (self.orga1.slug, self.event1.slug, action.pk)
+        )
+        assert resp.status_code == 405
+        action.refresh_from_db()
+        assert action.done is False
+
+    def test_required_action_discard_via_post(self):
+        from eventyay.base.models.event import RequiredAction
+
+        self.team1.can_change_orders = True
+        self.team1.save()
+        action = RequiredAction.objects.create(event=self.event1, action_type='test.action')
+        resp = self.client.post(
+            '/control/event/%s/%s/requiredactions/%s/discard' % (self.orga1.slug, self.event1.slug, action.pk)
+        )
+        assert resp.status_code == 302
+        action.refresh_from_db()
+        assert action.done is True
+
 
 class EventDeletionTest(SoupTest):
     @scopes_disabled()


### PR DESCRIPTION
Fixes #5541

## Summary

Several orga and control views wrote to the database on GET. Django skips CSRF on GET, so a logged-in organiser who loads one of those URLs from another page can hide a schedule, drop a speaker, or flip a review phase.

The discarded-dispatch pattern is in `ScheduleToggleView.dispatch` at `app/eventyay/orga/views/schedule.py:184` on `dev` (`43c97f9`). It calls `super().dispatch()` and then mutates anyway. `CfPQuestionToggle` at `cfp.py:654` still had a legacy GET write. The issue list is right. Two of its line numbers are off by one.

I moved the eight listed views to `post()`. GET now returns 405 and does not write. Templates submit POST forms with a CSRF token. `SubmissionType.urls.default` (`type.py:74`) now has a trailing slash so it matches the URLConf.

I skipped `ActionConfirmMixin` on speaker-remove and phase-activate, and I skipped a lint for discarded `super().dispatch()`. Those were extra to the CSRF hole. GET to these URLs is now a no-op. The organiser buttons still work.

## Test plan

- [x] WSL pytest, 21 CSRF cases: 21 passed in 95s
- [ ] GET on each listed URL returns 405 and does not write

## Summary by Sourcery

Require POST requests for state-changing organiser and control actions to close CSRF vulnerabilities from unsafe GET endpoints.

Bug Fixes:
- Prevent state-changing organiser and control views from mutating data when accessed with GET requests by requiring POST submissions.

Enhancements:
- Update affected interface actions to use CSRF-protected POST forms while preserving organiser workflows.
- Maintain JSON-based question toggles and correct submission-type default URL generation.

Tests:
- Add coverage confirming GET requests return 405 without changing state and POST requests continue to perform the intended actions.
- Add template checks to prevent nested forms in updated organiser pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security Improvements**
  - State-changing organizer and event-management actions now use CSRF-protected POST forms instead of GET links.
  - Direct GET requests to these actions are rejected to help prevent unintended changes.
  - Event admin access now requires a protected form submission.

- **Bug Fixes**
  - Submission-type default URLs now include a trailing slash.
  - Invalid requests receive a clear “Method Not Allowed” response.
  - Corrected form placement to prevent nested-form issues.

- **Tests**
  - Added coverage for POST behavior, CSRF protection, rejected GET requests, unchanged state, and form structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->