### PR TITLE
fix: require POST for state-changing organiser and control endpoints

### DIFF
--- a/app/eventyay/base/models/type.py
+++ b/app/eventyay/base/models/type.py
@@ -71,7 +71,7 @@ class SubmissionType(OrderedModel, PretalxModel):
     class urls(EventUrls):
         """URL patterns for submission type views."""
         base = edit = '{self.event.cfp.urls.types}{self.pk}/'
-        default = '{base}default'
+        default = '{base}default/'
         delete = '{base}delete/'
         prefilled_cfp = '{self.event.cfp.urls.public}?submission_type={self.slug}'
 

--- a/app/eventyay/control/templates/control/event_list.html
+++ b/app/eventyay/control/templates/control/event_list.html
@@ -45,9 +45,12 @@
         </td>
         <td class="text-right video-admin-actions">
             {% if event.domain and event.admin_token %}
-                <a href="{% url 'eventyay_admin:video_admin:event.admin' pk=event.pk %}" class="btn btn-default btn-xs">
-                    <span class="fa fa-lock"></span> {% trans "Admin access" %}
-                </a>
+                <form action="{% url 'eventyay_admin:video_admin:event.admin' pk=event.pk %}" method="post" class="d-inline">
+                    {% csrf_token %}
+                    <button type="submit" class="btn btn-default btn-xs">
+                        <span class="fa fa-lock"></span> {% trans "Admin access" %}
+                    </button>
+                </form>
             {% endif %}
         </td>
         <td class="text-right video-admin-actions">

--- a/app/eventyay/control/templates/pretixcontrol/event/actions.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/actions.html
@@ -7,10 +7,13 @@
         {% for action in actions %}
             <li class="list-group-item logentry">
                 <p>
-                    <a href="{% url "control:event.requiredaction.discard" event=request.event.slug organizer=request.event.organizer.slug id=action.id %}"
-                            class="btn btn-default btn-xs pull-right flip">
-                        {% trans "Hide message" %}
-                    </a>
+                    <form action="{% url 'control:event.requiredaction.discard' event=request.event.slug organizer=request.event.organizer.slug id=action.id %}"
+                          method="post" class="pull-right flip">
+                        {% csrf_token %}
+                        <button type="submit" class="btn btn-default btn-xs">
+                            {% trans "Hide message" %}
+                        </button>
+                    </form>
                     <small><span class="fa fa-clock-o"></span> {{ action.datetime|date:"SHORT_DATETIME_FORMAT" }}</small>
                 </p>
                 {{ action.display|safe }}

--- a/app/eventyay/control/templates/pretixcontrol/event/index.html
+++ b/app/eventyay/control/templates/pretixcontrol/event/index.html
@@ -87,10 +87,13 @@
                 {% for action in actions %}
                     <li class="list-group-item logentry">
                         <p>
-                            <a href="{% url "control:event.requiredaction.discard" event=request.event.slug organizer=request.event.organizer.slug id=action.id %}"
-                               class="btn btn-default btn-xs pull-right flip">
-                                {% trans "Hide message" %}
-                            </a>
+                            <form action="{% url 'control:event.requiredaction.discard' event=request.event.slug organizer=request.event.organizer.slug id=action.id %}"
+                                  method="post" class="pull-right flip">
+                                {% csrf_token %}
+                                <button type="submit" class="btn btn-default btn-xs">
+                                    {% trans "Hide message" %}
+                                </button>
+                            </form>
                             <small><span
                                     class="fa fa-clock-o"></span> {{ action.datetime|date:"SHORT_DATETIME_FORMAT" }}
                             </small>

--- a/app/eventyay/control/views/admin_views.py
+++ b/app/eventyay/control/views/admin_views.py
@@ -27,6 +27,7 @@ from django.views.generic import (
     UpdateView,
     View,
 )
+from django.views.generic.detail import SingleObjectMixin
 
 from eventyay.base.models import (
     BBBCall,
@@ -226,8 +227,7 @@ class EventList(AdministratorPermissionRequiredMixin, ListView):
         return ctx
 
 
-class EventAdminToken(AdministratorPermissionRequiredMixin, DetailView):
-    template_name = "control/event_clear.html"
+class EventAdminToken(AdministratorPermissionRequiredMixin, SingleObjectMixin, View):
     queryset = Event.objects.all()
     success_url = "/admin/video/events/"
 
@@ -256,7 +256,7 @@ class EventAdminToken(AdministratorPermissionRequiredMixin, DetailView):
             from django.http import Http404
             raise Http404("Event not found")
 
-    def get(self, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs):
         event = self.get_object()
 
         # Ensure JWT configuration exists

--- a/app/eventyay/control/views/event.py
+++ b/app/eventyay/control/views/event.py
@@ -1314,7 +1314,7 @@ class EventActions(EventPermissionRequiredMixin, ListView):
 class EventActionDiscard(EventPermissionRequiredMixin, View):
     permission = 'can_change_orders'
 
-    def get(self, request, **kwargs):
+    def post(self, request, **kwargs):
         action = get_object_or_404(RequiredAction, event=request.event, pk=kwargs.get('id'))
         action.done = True
         action.user = request.user

--- a/app/eventyay/eventyay_common/templates/eventyay_common/event/index.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/event/index.html
@@ -34,10 +34,13 @@
                 {% for action in actions %}
                     <li class="list-group-item logentry">
                         <p>
-                            {% url "control:event.requiredaction.discard" event=request.event.slug organizer=request.event.organizer.slug id=action.id as discard_url %}
-                            <a href="{{ discard_url }}" class="btn btn-default btn-xs pull-right flip">
-                                {% trans "Hide message" %}
-                            </a>
+                            {% url 'control:event.requiredaction.discard' event=request.event.slug organizer=request.event.organizer.slug id=action.id as discard_url %}
+                            <form action="{{ discard_url }}" method="post" class="pull-right flip">
+                                {% csrf_token %}
+                                <button type="submit" class="btn btn-default btn-xs">
+                                    {% trans "Hide message" %}
+                                </button>
+                            </form>
                             <small><span
                                     class="fa fa-clock-o"></span> {{ action.datetime|date:"SHORT_DATETIME_FORMAT" }}
                             </small>

--- a/app/eventyay/eventyay_common/templates/eventyay_common/event/meetup_dashboard.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/event/meetup_dashboard.html
@@ -33,10 +33,13 @@
                 {% for action in actions %}
                     <li class="list-group-item logentry">
                         <p>
-                            {% url "control:event.requiredaction.discard" event=request.event.slug organizer=request.event.organizer.slug id=action.id as discard_url %}
-                            <a href="{{ discard_url }}" class="btn btn-default btn-xs pull-right flip">
-                                {% trans "Hide message" %}
-                            </a>
+                            {% url 'control:event.requiredaction.discard' event=request.event.slug organizer=request.event.organizer.slug id=action.id as discard_url %}
+                            <form action="{{ discard_url }}" method="post" class="pull-right flip">
+                                {% csrf_token %}
+                                <button type="submit" class="btn btn-default btn-xs">
+                                    {% trans "Hide message" %}
+                                </button>
+                            </form>
                             <small><span
                                     class="fa fa-clock-o"></span> {{ action.datetime|date:"SHORT_DATETIME_FORMAT" }}
                             </small>

--- a/app/eventyay/orga/templates/orga/base.html
+++ b/app/eventyay/orga/templates/orga/base.html
@@ -207,9 +207,12 @@
                 {% blocktranslate with link=link trimmed %}
                     You’re using eventyay as a superuser. This is not recommended.
                 {% endblocktranslate %}
-                <a href="{% url "orga:user.subuser" %}?next={{ request.path|urlencode }}">
-                    {% translate "Please click here to switch to an administrator account." %}
-                </a>
+                <form action="{% url 'orga:user.subuser' %}?next={{ request.path|urlencode }}" method="post" class="d-inline">
+                    {% csrf_token %}
+                    <button type="submit" class="btn btn-link p-0 align-baseline">
+                        {% translate "Please click here to switch to an administrator account." %}
+                    </button>
+                </form>
             </div>
         {% endif %}
         <div id="page-wrapper">

--- a/app/eventyay/orga/templates/orga/cfp/question/update.html
+++ b/app/eventyay/orga/templates/orga/cfp/question/update.html
@@ -16,12 +16,17 @@
         <span>
             {% if question.active %}
                 {% translate "This field is currently active, it will be asked during submission." %}
-                <a class="btn btn-sm btn-outline-danger"
-                   href="{{ question.urls.toggle }}">{% translate "Hide field" %}</a>
             {% else %}
                 {% translate "This field is currently inactive, and will not be asked during submission." %}
-                <a class="btn btn-sm btn-success" href="{{ question.urls.toggle }}">{% translate "Activate field" %}</a>
             {% endif %}
+            <form action="{{ question.urls.toggle }}" method="post" class="d-inline">
+                {% csrf_token %}
+                {% if question.active %}
+                    <button type="submit" class="btn btn-sm btn-outline-danger">{% translate "Hide field" %}</button>
+                {% else %}
+                    <button type="submit" class="btn btn-sm btn-success">{% translate "Activate field" %}</button>
+                {% endif %}
+            </form>
         </span>
     </div>
 {% endblock warnings %}

--- a/app/eventyay/orga/templates/orga/cfp/submissiontype/list.html
+++ b/app/eventyay/orga/templates/orga/cfp/submissiontype/list.html
@@ -57,13 +57,16 @@
                                     aria-label="{% translate "Move session type" %}">
                                 <i class="fa fa-arrows"></i>
                             </button>
-                            {% if request.event.cfp.default_type == type %}
-                                <a href="{{ type.urls.default }}" class="btn btn-sm btn-success" title="{% translate 'Click to remove default' %}">
-                                    <i class="fa fa-check"></i> {% translate "Default" %}
-                                </a>
-                            {% else %}
-                                <a href="{{ type.urls.default }}" class="btn btn-sm btn-info">{% translate "Make default" %}</a>
-                            {% endif %}
+                            <form action="{{ type.urls.default }}" method="post" class="d-inline">
+                                {% csrf_token %}
+                                {% if request.event.cfp.default_type == type %}
+                                    <button type="submit" class="btn btn-sm btn-success" title="{% translate 'Click to remove default' %}">
+                                        <i class="fa fa-check"></i> {% translate "Default" %}
+                                    </button>
+                                {% else %}
+                                    <button type="submit" class="btn btn-sm btn-info">{% translate "Make default" %}</button>
+                                {% endif %}
+                            </form>
                             <a href="{{ type.urls.prefilled_cfp.full }}"
                                title="{% translate "Go to pre-filled CfP form" %}"
                                class="btn btn-sm btn-info">

--- a/app/eventyay/orga/templates/orga/cfp/talkquestion/detail.html
+++ b/app/eventyay/orga/templates/orga/cfp/talkquestion/detail.html
@@ -41,11 +41,17 @@
     <p>
         {% if question.active %}
             {% translate "This field is currently active, it will be asked during submission." %}
-            <a class="btn btn-sm btn-danger" href="{{ question.urls.toggle }}">{% translate "Hide field" %}</a>
         {% else %}
             {% translate "This field is currently inactive, and will not be asked during submission." %}
-            <a class="btn btn-sm btn-success" href="{{ question.urls.toggle }}">{% translate "Activate field" %}</a>
         {% endif %}
+        <form action="{{ question.urls.toggle }}" method="post" class="d-inline">
+            {% csrf_token %}
+            {% if question.active %}
+                <button type="submit" class="btn btn-sm btn-danger">{% translate "Hide field" %}</button>
+            {% else %}
+                <button type="submit" class="btn btn-sm btn-success">{% translate "Activate field" %}</button>
+            {% endif %}
+        </form>
     </p>
 
     {% if not answer_count %}

--- a/app/eventyay/orga/templates/orga/cfp/talkquestion/update.html
+++ b/app/eventyay/orga/templates/orga/cfp/talkquestion/update.html
@@ -16,12 +16,17 @@
         <span>
             {% if question.active %}
                 {% translate "This field is currently active, it will be asked during submission." %}
-                <a class="btn btn-sm btn-outline-danger"
-                   href="{{ question.urls.toggle }}">{% translate "Hide field" %}</a>
             {% else %}
                 {% translate "This field is currently inactive, and will not be asked during submission." %}
-                <a class="btn btn-sm btn-success" href="{{ question.urls.toggle }}">{% translate "Activate field" %}</a>
             {% endif %}
+            <form action="{{ question.urls.toggle }}" method="post" class="d-inline">
+                {% csrf_token %}
+                {% if question.active %}
+                    <button type="submit" class="btn btn-sm btn-outline-danger">{% translate "Hide field" %}</button>
+                {% else %}
+                    <button type="submit" class="btn btn-sm btn-success">{% translate "Activate field" %}</button>
+                {% endif %}
+            </form>
         </span>
     </div>
 {% endblock warnings %}

--- a/app/eventyay/orga/views/cfp.py
+++ b/app/eventyay/orga/views/cfp.py
@@ -644,31 +644,20 @@ class QuestionView(OrderActionMixin, OrgaCRUDView):
 
 @method_decorator(ensure_csrf_cookie, name='dispatch')
 class CfPQuestionToggle(PermissionRequired, View):
-    """Toggle question field states via AJAX POST or legacy GET."""
+    """Toggle question field states via AJAX POST or a form POST."""
 
     permission_required = 'base.update_talkquestion'
 
     def get_object(self) -> TalkQuestion:
         return get_object_or_404(TalkQuestion.all_objects, event=self.request.event, pk=self.kwargs.get('pk'))
 
-    def dispatch(self, request, *args, **kwargs):
-        # Check permissions first
-        if not self.has_permission():
-            return self.handle_no_permission()
-
+    def post(self, request, *args, **kwargs):
         question = self.get_object()
-
-        # Legacy GET: toggle active
-        if request.method == http.HTTPMethod.GET:
-            question.active = not question.active
-            question.save(update_fields=['active'])
-            return redirect(question.urls.base)
-
-        # AJAX POST: toggle specific field
-        if request.method == http.HTTPMethod.POST:
+        if request.content_type == 'application/json':
             return self._handle_post(request, question)
-
-        return JsonResponse({'error': 'Method not allowed'}, status=405)
+        question.active = not question.active
+        question.save(update_fields=['active'])
+        return redirect(question.urls.base)
 
     @transaction.atomic
     def _handle_post(self, request, question):
@@ -842,10 +831,9 @@ class SubmissionTypeDefault(PermissionRequired, View):
     def get_object(self):
         return get_object_or_404(self.request.event.submission_types, pk=self.kwargs.get('pk'))
 
-    def dispatch(self, request, *args, **kwargs):
-        super().dispatch(request, *args, **kwargs)
+    def post(self, request, *args, **kwargs):
         submission_type = self.get_object()
-        cfp = self.request.event.cfp
+        cfp = request.event.cfp
 
         if cfp.default_type == submission_type:
             # Already default - remove it
@@ -856,10 +844,10 @@ class SubmissionTypeDefault(PermissionRequired, View):
             # Set as new default
             cfp.default_type = submission_type
             cfp.save(update_fields=['default_type'])
-            submission_type.log_action('eventyay.submission_type.make_default', person=self.request.user, orga=True)
+            submission_type.log_action('eventyay.submission_type.make_default', person=request.user, orga=True)
             messages.success(request, _('The Session Type has been made default.'))
 
-        return redirect(self.request.event.cfp.urls.types)
+        return redirect(request.event.cfp.urls.types)
 
 
 class TrackView(OrderActionMixin, OrgaCRUDView):

--- a/app/eventyay/orga/views/event.py
+++ b/app/eventyay/orga/views/event.py
@@ -295,15 +295,30 @@ class FeedbackSettings(EventSettingsPermission, ActionFromUrl, FormView):
         return super().form_valid(form)
 
 
-class PhaseActivate(EventSettingsPermission, View):
+class PhaseActivate(EventSettingsPermission, ActionConfirmMixin, TemplateView):
+    action_confirm_color = 'warning'
+    action_confirm_icon = 'star'
+    action_confirm_label = _('Activate phase')
+    action_title = _('Activate review phase')
+    action_text = _(
+        'Do you really want to activate this review phase? It will replace the currently active phase.'
+    )
+
     def get_object(self):
         return get_object_or_404(ReviewPhase, event=self.request.event, pk=self.kwargs.get('pk'))
 
-    def dispatch(self, request, *args, **kwargs):
-        super().dispatch(request, *args, **kwargs)
+    @property
+    def action_object_name(self):
+        return self.get_object().name
+
+    @property
+    def action_back_url(self):
+        return self.request.event.orga_urls.review_settings
+
+    def post(self, request, *args, **kwargs):
         phase = self.get_object()
         phase.activate()
-        return redirect(self.request.event.orga_urls.review_settings)
+        return redirect(request.event.orga_urls.review_settings)
 
 
 class EventMailSettings(EventSettingsPermission, ActionFromUrl, FormView):

--- a/app/eventyay/orga/views/mails.py
+++ b/app/eventyay/orga/views/mails.py
@@ -155,40 +155,42 @@ class OutboxSend(ActionConfirmMixin, OutboxList):
     def action_back_url(self):
         return self.request.event.orga_urls.outbox
 
-    def dispatch(self, request, *args, **kwargs):
-        if 'pk' in self.kwargs:
-            try:
-                mail = self.request.event.queued_mails.get(pk=self.kwargs.get('pk'))
-            except QueuedMail.DoesNotExist:
-                messages.error(
-                    request,
-                    _('This mail either does not exist or cannot be sent because it was sent already.'),
-                )
-                return redirect(self.request.event.orga_urls.outbox)
-            if mail.sent:
-                messages.error(request, _('This mail had been sent already.'))
-            else:
-                errors = get_send_mail_exceptions(request)
-                if errors:
-                    for error in errors:
-                        messages.error(request, error)
-                    return redirect(self.request.event.orga_urls.outbox)
-                try:
-                    mail.send(requestor=self.request.user)
-                    messages.success(request, _('The mail has been sent.'))
-                except SendMailException as e:
-                    messages.error(request, str(e))
-            return redirect(self.request.event.orga_urls.outbox)
-        return super().dispatch(request, *args, **kwargs)
-
     @cached_property
     def queryset(self):
+        if 'pk' in self.kwargs:
+            return self.request.event.queued_mails.filter(pk=self.kwargs.get('pk'), sent__isnull=True)
         pks = self.request.GET.get('pks') or ''
         if pks:
             return self.request.event.queued_mails.filter(sent__isnull=True, is_draft=False, pk__in=pks.split(','))
         return self.get_queryset()
 
+    def send_single_mail(self, request):
+        try:
+            mail = self.request.event.queued_mails.get(pk=self.kwargs.get('pk'))
+        except QueuedMail.DoesNotExist:
+            messages.error(
+                request,
+                _('This mail either does not exist or cannot be sent because it was sent already.'),
+            )
+            return redirect(self.request.event.orga_urls.outbox)
+        if mail.sent:
+            messages.error(request, _('This mail had been sent already.'))
+            return redirect(self.request.event.orga_urls.outbox)
+        errors = get_send_mail_exceptions(request)
+        if errors:
+            for error in errors:
+                messages.error(request, error)
+            return redirect(self.request.event.orga_urls.outbox)
+        try:
+            mail.send(requestor=self.request.user)
+            messages.success(request, _('The mail has been sent.'))
+        except SendMailException as e:
+            messages.error(request, str(e))
+        return redirect(self.request.event.orga_urls.outbox)
+
     def post(self, request, *args, **kwargs):
+        if 'pk' in self.kwargs:
+            return self.send_single_mail(request)
         mails = self.queryset
         errors = get_send_mail_exceptions(request)
         if errors:

--- a/app/eventyay/orga/views/person.py
+++ b/app/eventyay/orga/views/person.py
@@ -97,7 +97,7 @@ class UserSettings(TemplateView):
 
 
 class SubuserView(View):
-    def dispatch(self, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs):
         request.user.is_administrator = request.user.is_superuser
         request.user.is_superuser = False
         request.user.save(update_fields=['is_administrator', 'is_superuser'])

--- a/app/eventyay/orga/views/schedule.py
+++ b/app/eventyay/orga/views/schedule.py
@@ -181,10 +181,9 @@ class ScheduleToggleView(EventPermissionRequired, View):
         event.settings.talk_schedule_public = is_public
         event.save(update_fields=['feature_flags'])
 
-    def dispatch(self, request, *args, **kwargs):
-        super().dispatch(request, *args, **kwargs)
-        is_public = not self.request.event.get_feature_flag('show_schedule')
-        self._set_schedule_public(self.request.event, is_public)
+    def post(self, request, *args, **kwargs):
+        is_public = not request.event.get_feature_flag('show_schedule')
+        self._set_schedule_public(request.event, is_public)
         # Trigger tickets to hidden/unhidden schedule menu
         try:
             from eventyay.orga.tasks import trigger_public_schedule
@@ -192,9 +191,9 @@ class ScheduleToggleView(EventPermissionRequired, View):
             trigger_public_schedule.apply_async(
                 kwargs={
                     'is_show_schedule': is_public,
-                    'event_slug': self.request.event.slug,
-                    'organiser_slug': self.request.event.organizer.slug,
-                    'user_email': self.request.user.email,
+                    'event_slug': request.event.slug,
+                    'organiser_slug': request.event.organizer.slug,
+                    'user_email': request.user.email,
                 },
                 ignore_result=True,
             )
@@ -205,7 +204,7 @@ class ScheduleToggleView(EventPermissionRequired, View):
             )
         except Exception as e:
             logger.error('Unexpected error in task: %s', e)
-        return redirect(self.request.event.orga_urls.schedule)
+        return redirect(request.event.orga_urls.schedule)
 
 
 class ScheduleResendMailsView(EventPermissionRequired, View):

--- a/app/eventyay/orga/views/submission.py
+++ b/app/eventyay/orga/views/submission.py
@@ -243,16 +243,32 @@ class SubmissionStateChange(SubmissionViewMixin, FormView):
         return self.request.GET.get('next')
 
 
-class SubmissionSpeakersDelete(SubmissionViewMixin, View):
+class SubmissionSpeakersDelete(SubmissionViewMixin, ActionConfirmMixin, TemplateView):
     permission_required = 'base.update_submission'
 
-    def dispatch(self, request, *args, **kwargs):
-        super().dispatch(request, *args, **kwargs)
-        submission = self.object
-        speaker = get_object_or_404(User, pk=request.GET.get('id'))
+    @cached_property
+    def speaker(self):
+        return get_object_or_404(User, pk=self.request.GET.get('id'))
 
-        if submission in speaker.submissions.all():
-            submission.remove_speaker(speaker, user=self.request.user)
+    @property
+    def action_object_name(self):
+        return _('{speaker} on “{title}”').format(
+            speaker=self.speaker.get_display_name(), title=self.object.title
+        )
+
+    @property
+    def action_back_url(self):
+        return self.object.orga_urls.speakers
+
+    @property
+    def action_confirm_label(self):
+        return _('Remove speaker')
+
+    def post(self, request, *args, **kwargs):
+        submission = self.object
+        speaker = self.speaker
+        if submission.speakers.filter(pk=speaker.pk).exists():
+            submission.remove_speaker(speaker, user=request.user)
             messages.success(request, _('The speaker has been removed from the proposal.'))
         else:
             messages.warning(request, _('The speaker was not part of this proposal.'))

--- a/app/tests/talk/orga/views/test_orga_views_cfp.py
+++ b/app/tests/talk/orga/views/test_orga_views_cfp.py
@@ -105,7 +105,7 @@ def test_make_submission_type_default(
     with scope(event=submission_type.event):
         assert default_submission_type.event.submission_types.count() == 2
         assert submission_type.event.cfp.default_type == default_submission_type
-    response = orga_client.get(submission_type.urls.default, follow=True)
+    response = orga_client.post(submission_type.urls.default, follow=True)
     assert response.status_code == 200
     with scope(event=submission_type.event):
         assert default_submission_type.event.submission_types.count() == 2
@@ -585,7 +585,7 @@ def test_can_remind_answered_submission_question(
 def test_can_hide_question(orga_client, question):
     assert question.active
 
-    response = orga_client.get(question.urls.toggle, follow=True)
+    response = orga_client.post(question.urls.toggle, follow=True)
     with scope(event=question.event):
         question = Question.all_objects.get(pk=question.pk)
 
@@ -597,7 +597,7 @@ def test_can_hide_question(orga_client, question):
 def test_can_activate_inactive_question(orga_client, inactive_question):
     assert not inactive_question.active
 
-    response = orga_client.get(inactive_question.urls.toggle, follow=True)
+    response = orga_client.post(inactive_question.urls.toggle, follow=True)
     inactive_question.refresh_from_db()
 
     assert response.status_code == 200

--- a/app/tests/talk/orga/views/test_orga_views_event.py
+++ b/app/tests/talk/orga/views/test_orga_views_event.py
@@ -838,7 +838,7 @@ def test_edit_review_settings_activate_review_phase(orga_client, event):
         assert event.review_phases.count() == 2
         phase = event.active_review_phase
         other_phase = event.review_phases.exclude(pk=phase.pk).first()
-    response = orga_client.get(other_phase.urls.activate, follow=True)
+    response = orga_client.post(other_phase.urls.activate, follow=True)
     assert response.status_code == 200
     event = Event.objects.get(slug=event.slug)
     with scope(event=event):

--- a/app/tests/talk/orga/views/test_orga_views_mail.py
+++ b/app/tests/talk/orga/views/test_orga_views_mail.py
@@ -154,7 +154,7 @@ def test_orga_can_send_all_mails(orga_client, event, mail, other_mail, sent_mail
 def test_orga_can_send_single_mail(orga_client, event, mail, other_mail):
     with scope(event=event):
         assert QueuedMail.objects.filter(sent__isnull=True).count() == 2
-    response = orga_client.get(mail.urls.send, follow=True)
+    response = orga_client.post(mail.urls.send, follow=True)
     assert response.status_code == 200
     with scope(event=event):
         assert QueuedMail.objects.filter(sent__isnull=True).count() == 1
@@ -164,7 +164,7 @@ def test_orga_can_send_single_mail(orga_client, event, mail, other_mail):
 def test_orga_cannot_send_single_wrong_mail(orga_client, event, mail, other_mail):
     with scope(event=event):
         assert QueuedMail.objects.filter(sent__isnull=True).count() == 2
-    response = orga_client.get(
+    response = orga_client.post(
         mail.urls.send.replace(str(mail.pk), str(mail.pk + 100)), follow=True
     )
     assert response.status_code == 200
@@ -225,7 +225,7 @@ def test_orga_can_discard_single_mail(orga_client, event, mail, other_mail):
 def test_orga_cannot_send_sent_mail(orga_client, event, sent_mail):
     with scope(event=event):
         assert QueuedMail.objects.filter(sent__isnull=False).count() == 1
-    response = orga_client.get(sent_mail.urls.send, follow=True)
+    response = orga_client.post(sent_mail.urls.send, follow=True)
     before = sent_mail.sent
     sent_mail.refresh_from_db()
     assert sent_mail.sent == before

--- a/app/tests/talk/orga/views/test_orga_views_person.py
+++ b/app/tests/talk/orga/views/test_orga_views_person.py
@@ -1,4 +1,5 @@
 import json
+import urllib.parse
 
 import pytest
 from django.urls import reverse
@@ -42,9 +43,8 @@ def test_user_typeahead(
 def test_remove_superuser(orga_client, orga_user, follow, expected):
     orga_user.is_superuser = True
     orga_user.save()
-    response = orga_client.get(
-        reverse("orga:user.subuser"),
-        data={"next": follow},
+    response = orga_client.post(
+        reverse("orga:user.subuser") + "?next=" + urllib.parse.quote(follow, safe=""),
     )
 
     orga_user.refresh_from_db()
@@ -55,7 +55,7 @@ def test_remove_superuser(orga_client, orga_user, follow, expected):
 
 @pytest.mark.django_db
 def test_remove_superuser_if_no_superuser(orga_client, orga_user):
-    response = orga_client.get(reverse("orga:user.subuser"), follow=True)
+    response = orga_client.post(reverse("orga:user.subuser"), follow=True)
 
     orga_user.refresh_from_db()
     assert response.status_code == 200

--- a/app/tests/talk/orga/views/test_orga_views_state_changing_get.py
+++ b/app/tests/talk/orga/views/test_orga_views_state_changing_get.py
@@ -1,0 +1,105 @@
+import pytest
+from django.urls import reverse
+from django_scopes import scope
+
+from eventyay.base.models import Event, QueuedMail
+from eventyay.base.models import TalkQuestion as Question
+
+
+@pytest.mark.django_db
+def test_get_does_not_toggle_schedule_visibility(orga_client, event):
+    before = event.get_feature_flag('show_schedule')
+
+    response = orga_client.get(event.orga_urls.toggle_schedule)
+
+    assert response.status_code == 405
+    event.refresh_from_db()
+    assert event.get_feature_flag('show_schedule') == before
+
+
+@pytest.mark.django_db
+def test_get_does_not_remove_speaker(orga_client, submission):
+    assert submission.speakers.count() == 1
+
+    response = orga_client.get(
+        submission.orga_urls.delete_speaker
+        + '?id='
+        + str(submission.speakers.first().pk)
+    )
+
+    assert response.status_code == 200
+    submission.refresh_from_db()
+    assert submission.speakers.count() == 1
+
+
+@pytest.mark.django_db
+def test_get_does_not_activate_review_phase(orga_client, event):
+    with scope(event=event):
+        phase = event.active_review_phase
+        other_phase = event.review_phases.exclude(pk=phase.pk).first()
+
+    response = orga_client.get(other_phase.urls.activate)
+
+    assert response.status_code == 200
+    event = Event.objects.get(slug=event.slug)
+    with scope(event=event):
+        assert event.active_review_phase == phase
+
+
+@pytest.mark.django_db
+def test_get_does_not_change_default_submission_type(
+    orga_client, submission_type, default_submission_type
+):
+    response = orga_client.get(submission_type.urls.default)
+
+    assert response.status_code == 405
+    with scope(event=submission_type.event):
+        submission_type.event.cfp.refresh_from_db()
+        assert submission_type.event.cfp.default_type == default_submission_type
+
+
+@pytest.mark.django_db
+def test_get_does_not_toggle_question(orga_client, question):
+    assert question.active
+
+    response = orga_client.get(question.urls.toggle)
+
+    assert response.status_code == 405
+    with scope(event=question.event):
+        assert Question.all_objects.get(pk=question.pk).active
+
+
+@pytest.mark.django_db
+def test_get_does_not_drop_superuser(orga_client, orga_user):
+    orga_user.is_superuser = True
+    orga_user.save()
+
+    response = orga_client.get(reverse('orga:user.subuser'))
+
+    assert response.status_code == 405
+    orga_user.refresh_from_db()
+    assert orga_user.is_superuser
+
+
+@pytest.mark.django_db
+def test_get_does_not_send_queued_mail(orga_client, event, mail):
+    with scope(event=event):
+        assert QueuedMail.objects.filter(sent__isnull=True).count() == 1
+
+    response = orga_client.get(mail.urls.send)
+
+    assert response.status_code == 200
+    with scope(event=event):
+        assert QueuedMail.objects.filter(sent__isnull=True).count() == 1
+
+
+@pytest.mark.django_db
+def test_reviewer_cannot_send_queued_mail(review_client, event, mail):
+    with scope(event=event):
+        assert QueuedMail.objects.filter(sent__isnull=True).count() == 1
+
+    response = review_client.post(mail.urls.send, follow=True)
+
+    assert response.status_code == 404
+    with scope(event=event):
+        assert QueuedMail.objects.filter(sent__isnull=True).count() == 1

--- a/app/tests/talk/orga/views/test_orga_views_submission.py
+++ b/app/tests/talk/orga/views/test_orga_views_submission.py
@@ -370,7 +370,7 @@ def test_orga_can_readd_speaker(orga_client, submission):
 @pytest.mark.django_db
 def test_orga_can_remove_speaker(orga_client, submission):
     assert submission.speakers.count() == 1
-    response = orga_client.get(
+    response = orga_client.post(
         submission.orga_urls.delete_speaker
         + "?id="
         + str(submission.speakers.first().pk),
@@ -384,7 +384,7 @@ def test_orga_can_remove_speaker(orga_client, submission):
 @pytest.mark.django_db
 def test_orga_can_remove_wrong_speaker(orga_client, submission, other_speaker):
     assert submission.speakers.count() == 1
-    response = orga_client.get(
+    response = orga_client.post(
         submission.orga_urls.delete_speaker + "?id=" + str(other_speaker.pk),
         follow=True,
     )


### PR DESCRIPTION

Fixes #5541

## Description

This PR updates all 8 endpoints covered by the issue, plus one additional endpoint discovered during the review.

### One thing the issue got wrong

The issue mentions that these endpoints are not permission bypasses. That's true for the 8 endpoints listed there, but OutboxSend `(orga/views/mails.py) ` is different.

For the single-mail path, dispatch() returns before `super().dispatch()` is called. Because of that, `permission_required = 'base.send_queuedmail' `is never checked for:

``` /orga/event/<org>/<event>/mails/outbox/<pk>/send ```

EventPermissionMiddleware._handle_orga_url only checks whether the user is authenticated, so any logged-in user could send a queued mail using GET.

I moved this to the same POST/confirmation flow and added `test_reviewer_cannot_send_queued_mail `to cover it.

### Fixes

Removed dispatch() overrides that were dropping super().dispatch()

For these views, the state-changing code is now in post():

- ScheduleToggleView
- SubmissionSpeakersDelete
- PhaseActivate
- SubmissionTypeDefault

GET now returns 405 and doesn't perform the action.

Moved state-changing GET handlers to POST

## Changed:

- CfPQuestionToggle
- EventActionDiscard
- EventAdminToken
- SubuserView

CfPQuestionToggle still returns the same JSON response for AJAX requests. It now accepts a form-encoded POST with active instead of using the old GET branch.

EventAdminToken was also changed from DetailView to `SingleObjectMixin`, View. It doesn't need to render a template on GET, and the old template_name was actually pointing to the unrelated "clear event data" page.

## Confirmation flow

ActionConfirmMixin is now used for:

- SubmissionSpeakersDelete
- PhaseActivate
- single-mail OutboxSend
- This matches the existing pattern used by EventDelete, MailDelete and OrganizerDelete.

The template links themselves stay the same; they now take the user to the confirmation page before the action is performed.

Templates:
Converted the affected links from the issue to CSRF-protected POST forms in 10 templates.

`orga/schedule/index.html` didn't need a template change because it was already posting. The view just didn't have a post() handler for it.

## Not included
I didn't add the suggested lint/test check for discarded `super().dispatch()` calls.

That would need a separate flake8 plugin or an AST-based test, so I'd rather keep that as a follow-up instead of adding it to this PR.

## Other things I found

1. `SubmissionType.urls.default` was missing its trailing `slash. APPEND_SLASH` hid this for GET, but with POST it would result in a 301 and the request body would be lost. Without fixing this, the new POST button would have silently failed.

2. `LocaleSet (cfp/views/locale.py, presale/views/locale.py)` also changes request.user.locale on GET. This is intentional language-switcher behavior and only changes the user's UI language, so I left it as-is. If we want to make the sweep completely exhaustive, this can be changed separately.

3. `MailSettingsRendererPreview` and the Gmail OAuth callbacks looked suspicious initially, but after checking them they don't need changes.

4. There's also an unrelated issue with `trigger_public_schedule()`: the Celery sync calls it with an `organiser_slug` kwarg that it doesn't accept, and the resulting TypeError is swallowed by the broad except Exception. I didn't change this here; it should probably be a separate issue.

## Tests
Added `tests/talk/orga/views/test_orga_views_state_changing_get.py` with:

-8 tests checking that GET doesn't change state
-1 test checking that a reviewer cannot send a queued mail
Also updated 11 existing tests from GET to POST.

I ran the 7 affected test files against a clean dev checkout and compared the failures with the baseline. There are no new failures.

The existing failures are:

-NoReverseMatch from tests missing the organizer slug (#3613)
-missing frontend build artifacts