### PR TITLE
Fix: Event settings scrolls to middle on load (#5552)

### DIFF
--- a/app/eventyay/eventyay_common/templates/eventyay_common/event/settings.html
+++ b/app/eventyay/eventyay_common/templates/eventyay_common/event/settings.html
@@ -547,4 +547,11 @@
     {% csrf_token %}
 </form>
 <script src="{% static 'eventyay-common/js/event-settings-images.js' %}" type="module"></script>
+<script>
+    window.addEventListener('load', function () {
+        setTimeout(function () {
+            window.scrollTo(0, 0);
+        }, 0);
+    });
+</script>
 {% endblock %}


### PR DESCRIPTION
Fixes #5552

## Summary
When navigating to the Event Settings page, the page opened scrolled down to the middle. This PR resets the scroll position to the top (`(0, 0)`) once the page finishes loading.

https://github.com/user-attachments/assets/087c0698-5464-4364-b031-c1c306c10a2b

