### PR TITLE
fix(feedback): disable session feedback by default (#5553)

### DIFF
--- a/app/tests/talk/agenda/views/test_agenda_feedback.py
+++ b/app/tests/talk/agenda/views/test_agenda_feedback.py
@@ -9,6 +9,8 @@ from eventyay.base.models import TalkSlot
 
 @pytest.mark.django_db()
 def test_can_create_feedback(django_assert_num_queries, past_slot, client, event):
+    event.feature_flags['use_feedback'] = True
+    event.save(update_fields=['feature_flags'])
     with scope(event=event):
         assert past_slot.submission.speakers.count() == 1
     with django_assert_num_queries(42):
@@ -29,6 +31,8 @@ def test_can_create_feedback(django_assert_num_queries, past_slot, client, event
 def test_can_create_feedback_for_multiple_speakers(
     django_assert_num_queries, past_slot, client, other_speaker, speaker, event
 ):
+    event.feature_flags['use_feedback'] = True
+    event.save(update_fields=['feature_flags'])
     with scope(event=event):
         past_slot.submission.speakers.add(other_speaker)
         past_slot.submission.speakers.add(speaker)
@@ -48,6 +52,8 @@ def test_can_create_feedback_for_multiple_speakers(
 def test_cannot_create_feedback_before_talk(
     django_assert_num_queries, slot, client, event
 ):
+    event.feature_flags['use_feedback'] = True
+    event.save(update_fields=['feature_flags'])
     _now = now()
     with scope(event=event):
         TalkSlot.objects.filter(submission__event=slot.event).update(

--- a/app/tests/talk/agenda/views/test_agenda_feedback.py
+++ b/app/tests/talk/agenda/views/test_agenda_feedback.py
@@ -72,6 +72,8 @@ def test_cannot_create_feedback_before_talk(
 
 @pytest.mark.django_db()
 def test_can_see_feedback(django_assert_num_queries, feedback, client):
+    feedback.talk.event.feature_flags['use_feedback'] = True
+    feedback.talk.event.save(update_fields=['feature_flags'])
     client.force_login(feedback.talk.speakers.first())
     with django_assert_num_queries(17):
         response = client.get(feedback.talk.urls.feedback)
@@ -80,14 +82,18 @@ def test_can_see_feedback(django_assert_num_queries, feedback, client):
 
 
 @pytest.mark.django_db()
-def test_can_see_feedback_form(django_assert_num_queries, past_slot, client):
+def test_can_see_feedback_form(django_assert_num_queries, past_slot, client, event):
+    event.feature_flags['use_feedback'] = True
+    event.save(update_fields=['feature_flags'])
     with django_assert_num_queries(13):
         response = client.get(past_slot.submission.urls.feedback, follow=True)
     assert response.status_code == 200
 
 
 @pytest.mark.django_db()
-def test_cannot_see_feedback_form_before_talk(django_assert_num_queries, slot, client):
+def test_cannot_see_feedback_form_before_talk(django_assert_num_queries, slot, client, event):
+    event.feature_flags['use_feedback'] = True
+    event.save(update_fields=['feature_flags'])
     with django_assert_num_queries(15):
         response = client.get(slot.submission.urls.feedback, follow=True)
     assert response.status_code == 200

--- a/app/tests/talk/agenda/views/test_agenda_talks.py
+++ b/app/tests/talk/agenda/views/test_agenda_talks.py
@@ -107,6 +107,8 @@ def test_can_see_talk_do_not_record(client, event, django_assert_num_queries, sl
 
 @pytest.mark.django_db
 def test_can_see_talk_does_accept_feedback(client, django_assert_num_queries, event, slot):
+    event.feature_flags['use_feedback'] = True
+    event.save(update_fields=['feature_flags'])
     with scope(event=event):
         slot.start = now() - dt.timedelta(days=1)
         slot.end = slot.start + dt.timedelta(hours=1)

--- a/app/tests/talk/event/test_event_model.py
+++ b/app/tests/talk/event/test_event_model.py
@@ -351,3 +351,12 @@ def test_event_update_review_phase_activate_next_phase(event):
         active_phase.save()
         new_phase = ReviewPhase.objects.create(event=event, position=3, start=active_phase.end)
         assert event.update_review_phase() == new_phase
+
+
+@pytest.mark.django_db
+def test_use_feedback_disabled_by_default(event):
+    """use_feedback should be False by default so organizers must opt-in.
+
+    See https://github.com/fossasia/eventyay/issues/5553
+    """
+    assert event.feature_flags['use_feedback'] is False


### PR DESCRIPTION
## Description

Closes #5553

The **Enable feedback for sessions** checkbox was previously enabled by default for new events. The model default was changed to False in #5425, but the existing tests were never updated to explicitly opt-in, meaning a future regression could go undetected.

## Changes

- **	est_event_model.py**: Added 	est_use_feedback_disabled_by_default — a regression test asserting event.feature_flags['use_feedback'] is False on freshly created events.
- **	est_agenda_feedback.py**: Explicitly sets use_feedback = True on the event in tests that require feedback submission/viewing, since the default is now False.
- **	est_agenda_talks.py**: Explicitly enables use_feedback in the test that verifies the feedback icon appears on talk pages.

## Acceptance Criteria

- [x] Default state of `Enable feedback for sessions` is `false` (unchecked) — verified by default_feature_flags() returning 'use_feedback': False.
- [x] Model defaults and API initial state align — the API reads from event.feature_flags which uses the model default.
- [x] Tests explicitly opt-in to feedback where needed.
- [x] Regression test ensures the default stays disabled.

##screenshot
<img width="1142" height="717" alt="image" src="https://github.com/user-attachments/assets/59f166b8-8945-4232-8783-e59e9ab5db62" />


## Summary by Sourcery

Ensure session feedback remains opt-in by default and keep affected tests aligned with that behavior.

Bug Fixes:
- Keep session feedback disabled by default for newly created events.

Enhancements:
- Update feedback-related tests to explicitly opt in to session feedback when required.

Tests:
- Add a regression test verifying that newly created events have session feedback disabled by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for event feedback when the feature is enabled.
  * Verified feedback is disabled by default for newly created events.
  * Confirmed feedback interactions work for multiple speakers and different talk stages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->