### PR TITLE
feat: enforce email.bulk.monthly capabilities

### DIFF
--- a/app/eventyay/orga/views/mails.py
+++ b/app/eventyay/orga/views/mails.py
@@ -14,6 +14,7 @@ from django.views.generic import FormView, ListView, TemplateView, View
 from django_context_decorator import context
 from i18nfield.strings import LazyI18nString
 
+from eventyay.base.entitlements import check_entitlement
 from eventyay.base.models.mail import MailTemplate, QueuedMail, get_prefixed_subject
 from eventyay.base.signals import entitlement_usage_recorded
 from eventyay.common.exceptions import SendMailException
@@ -617,6 +618,18 @@ class ComposeMailBaseView(EventPermissionRequired, FormView):
             message = form.empty_audience_draft_error if is_draft else form.empty_audience_error
             form.add_error(None, message)
             return self.render_to_response(self.get_context_data(form=form))
+
+        if not is_draft:
+            recipients_count = len(form.get_recipients())
+            decision = check_entitlement(
+                self.request.event.organizer,
+                'email.bulk.monthly',
+                event=self.request.event,
+                quantity=recipients_count
+            )
+            if not decision.allowed:
+                form.add_error(None, decision.message)
+                return self.render_to_response(self.get_context_data(form=form))
 
         with transaction.atomic():
             result = form.save()

--- a/app/eventyay/orga/views/mails.py
+++ b/app/eventyay/orga/views/mails.py
@@ -238,8 +238,33 @@ class DraftToOutbox(PermissionRequired, ActionConfirmMixin, TemplateView):
 
     def post(self, request, *args, **kwargs):
         mail = self.object
-        mail.is_draft = False
-        mail.save(update_fields=['is_draft'])
+        decision = check_entitlement(
+            self.request.event.organizer,
+            'email.bulk.monthly',
+            event=self.request.event,
+            quantity=1,
+        )
+        if not decision.allowed:
+            error_msg = decision.message or _(
+                'You have reached the limit for sending bulk emails on your plan.'
+            )
+            messages.error(request, error_msg)
+            return redirect(self.request.event.orga_urls.drafts)
+
+        with transaction.atomic():
+            entitlement_usage_recorded.send(
+                sender=self.request.event.organizer,
+                capability='email.bulk.monthly',
+                quantity=1,
+                unit='emails',
+                source_type='bulk_email',
+                source_id=str(mail.pk),
+                idempotency_key=f'bulk_mail_draft_to_outbox_{mail.pk}',
+                event=self.request.event,
+            )
+            mail.is_draft = False
+            mail.save(update_fields=['is_draft'])
+
         messages.success(request, _('The draft has been moved to the outbox.'))
         return redirect(self.request.event.orga_urls.outbox)
 
@@ -628,7 +653,10 @@ class ComposeMailBaseView(EventPermissionRequired, FormView):
                 quantity=recipients_count
             )
             if not decision.allowed:
-                form.add_error(None, decision.message)
+                error_msg = decision.message or _(
+                    'You have reached the limit for sending bulk emails on your plan.'
+                )
+                form.add_error(None, error_msg)
                 return self.render_to_response(self.get_context_data(form=form))
 
         with transaction.atomic():

--- a/app/tests/talk/orga/views/test_orga_views_mail.py
+++ b/app/tests/talk/orga/views/test_orga_views_mail.py
@@ -1403,3 +1403,48 @@ def test_session_test_mail_uses_fallbacks_for_empty_subject_and_body(orga_client
     with scope(event=event):
         assert QueuedMail.objects.count() == 0
 
+
+@pytest.mark.django_db
+def test_compose_session_mail_denied_by_entitlement(
+    orga_client, event, speaker, submission
+):
+    from unittest.mock import patch
+    from eventyay.base.entitlements import EntitlementDecision
+    from eventyay.orga.forms.mails import WriteSessionMailForm
+
+    with patch(
+        "eventyay.orga.views.mails.check_entitlement",
+        return_value=EntitlementDecision(
+            allowed=False,
+            reason_code="tier_limit_exceeded",
+            message="Monthly email limit reached for this plan.",
+        ),
+    ) as mock_check, patch.object(WriteSessionMailForm, "save") as mock_save:
+        response = orga_client.post(
+            event.orga_urls.compose_mails_sessions,
+            follow=True,
+            data={
+                "state": "submitted",
+                "bcc": "",
+                "cc": "",
+                "reply_to": "",
+                "subject_0": "foo {name}",
+                "text_0": "bar {submission_title}",
+            },
+        )
+        assert response.status_code == 200
+        assert (
+            "Monthly email limit reached for this plan."
+            in response.context["form"].non_field_errors()
+        )
+        mock_check.assert_called_once_with(
+            event.organizer,
+            "email.bulk.monthly",
+            event=event,
+            quantity=1,
+        )
+        mock_save.assert_not_called()
+        with scope(event=event):
+            assert not QueuedMail.objects.filter(sent__isnull=True).exists()
+
+

--- a/app/tests/talk/orga/views/test_orga_views_mail.py
+++ b/app/tests/talk/orga/views/test_orga_views_mail.py
@@ -1,12 +1,14 @@
 import datetime as dt
+from unittest.mock import patch
 
 import pytest
 from django.core import mail as djmail
 from django.utils.timezone import now
 from django_scopes import scope
 
+from eventyay.base.entitlements import EntitlementDecision
 from eventyay.base.models import MailTemplate, MailTemplateRoles, QueuedMail
-from eventyay.orga.forms.mails import MailDetailForm
+from eventyay.orga.forms.mails import MailDetailForm, WriteSessionMailForm
 
 
 @pytest.mark.django_db
@@ -1408,10 +1410,6 @@ def test_session_test_mail_uses_fallbacks_for_empty_subject_and_body(orga_client
 def test_compose_session_mail_denied_by_entitlement(
     orga_client, event, speaker, submission
 ):
-    from unittest.mock import patch
-    from eventyay.base.entitlements import EntitlementDecision
-    from eventyay.orga.forms.mails import WriteSessionMailForm
-
     with patch(
         "eventyay.orga.views.mails.check_entitlement",
         return_value=EntitlementDecision(
@@ -1446,5 +1444,35 @@ def test_compose_session_mail_denied_by_entitlement(
         mock_save.assert_not_called()
         with scope(event=event):
             assert not QueuedMail.objects.filter(sent__isnull=True).exists()
+
+
+@pytest.mark.django_db
+def test_draft_to_outbox_denied_by_entitlement(orga_client, event, mail):
+    with scope(event=event):
+        mail.is_draft = True
+        mail.save()
+
+    with patch(
+        "eventyay.orga.views.mails.check_entitlement",
+        return_value=EntitlementDecision(
+            allowed=False,
+            reason_code="tier_limit_exceeded",
+            message="Monthly email limit reached for this plan.",
+        ),
+    ) as mock_check:
+        response = orga_client.post(mail.urls.to_outbox, follow=True)
+        assert response.status_code == 200
+        with scope(event=event):
+            mail.refresh_from_db()
+            assert mail.is_draft is True
+            assert mail.sent is None
+
+        mock_check.assert_called_once_with(
+            event.organizer,
+            "email.bulk.monthly",
+            event=event,
+            quantity=1,
+        )
+
 
 


### PR DESCRIPTION
## Description

This PR implements the missing enforcement hook for the `email.bulk.monthly` tier capability.

### What is restricted?
It hooks into `ComposeMailBaseView.post()`, which means it successfully restricts **mass bulk emails sent via the Organizer dashboard**:
- Mass emails sent to **Speakers / Sessions**
- Mass emails sent to **Event Team members / Staff**

### What is NOT restricted?
It intentionally does **not** restrict transactional emails:
- Automated post-purchase ticket emails
- Queued transactional emails (password resets, payment reminders, etc.)
- (Currently, mass emails sent to Attendees via the `sendmail` plugin are handled separately and bypass this specific base view hook).

Depends on plugin PR: https://github.com/fossasia/eventyay-business/pull/58

## Summary by Sourcery

Enforce monthly bulk email entitlements across Organizer bulk email sending flows.

New Features:
- Enforce the `email.bulk.monthly` entitlement for Organizer bulk email composition and draft delivery.

Enhancements:
- Record bulk email entitlement usage atomically when drafts are moved to the outbox.
- Add coverage for entitlement-denied bulk email composition and draft delivery.

Tests:
- Add tests verifying denied bulk emails are not saved or sent and drafts remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added entitlement checks when moving draft bulk emails to the outbox.
  - Approved emails now record usage when queued for delivery.
  - Draft emails can still be saved without passing the entitlement check.

- **Bug Fixes**
  - Prevented bulk emails from being queued when entitlement is insufficient.
  - Blocked transitions leave drafts unchanged and unsent.
  - Added a fallback error message when entitlement details are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->