### PR TITLE
Fix: Respect session-type deadlines in public CfP list

### DIFF
--- a/app/eventyay/presale/views/startpage.py
+++ b/app/eventyay/presale/views/startpage.py
@@ -168,7 +168,13 @@ class UpcomingEventsView(PaginationMixin, ListView):
             .filter(testmode=False)
         ).order_by('date_from')
         if self.request.GET.get('cfp') == 'open':
-            qs = qs.filter(Q(cfp__deadline__isnull=True) | Q(cfp__deadline__gte=timezone.now()))
+            # Mirror CfP.is_open: a session type may extend the CfP beyond the general deadline.
+            now = timezone.now()
+            qs = qs.filter(
+                Q(cfp__deadline__isnull=True)
+                | Q(cfp__deadline__gte=now)
+                | Q(submission_types__deadline__gte=now)
+            ).distinct()
         return qs
 
     def get_context_data(self, **kwargs):

--- a/app/eventyay/presale/views/startpage.py
+++ b/app/eventyay/presale/views/startpage.py
@@ -158,6 +158,7 @@ class UpcomingEventsView(PaginationMixin, ListView):
     paginate_by = 20
 
     def get_queryset(self):
+        """Return a queryset of upcoming events, optionally filtered by open CfP status."""
         today_datetime = timezone.localtime().replace(hour=0, minute=0, second=0, microsecond=0)
         qs = Event.exclude_talks_testmode(
             Event.objects.select_related('organizer')
@@ -178,6 +179,7 @@ class UpcomingEventsView(PaginationMixin, ListView):
         return qs
 
     def get_context_data(self, **kwargs):
+        """Provide additional context variables for rendering the upcoming events list."""
         ctx = super().get_context_data(**kwargs)
         ctx['pagination_sizes'] = [20, 50, 100]
         ctx['cfp_open_filter'] = self.request.GET.get('cfp') == 'open'

--- a/app/tests/tickets/presale/test_startpage_optimization.py
+++ b/app/tests/tickets/presale/test_startpage_optimization.py
@@ -125,6 +125,7 @@ def test_startpage_keeps_featured_when_talks_testmode_false_and_other_true_setti
 
 @pytest.mark.django_db
 def test_upcoming_cfp_open_filter_respects_session_type_deadlines(startpage_events, client):
+    """Ensure the upcoming events 'Open calls for proposals' filter checks session-type deadlines."""
     _, _, e_upcoming, _ = startpage_events
     with scopes_disabled():
         cfp = CfP.objects.filter(event=e_upcoming).first()
@@ -142,6 +143,7 @@ def test_upcoming_cfp_open_filter_respects_session_type_deadlines(startpage_even
 
 @pytest.mark.django_db
 def test_startpage_hides_events_with_talks_testmode_true(startpage_events, client):
+    """Ensure events with talks_testmode=True are hidden from the start page."""
     _, e_featured, _, _ = startpage_events
     with scopes_disabled():
         e_featured.settings.set('talks_testmode', True)

--- a/app/tests/tickets/presale/test_startpage_optimization.py
+++ b/app/tests/tickets/presale/test_startpage_optimization.py
@@ -5,6 +5,8 @@ from django.utils.timezone import now
 from django_scopes import scopes_disabled
 
 from eventyay.base.models import Event, Organizer
+from eventyay.base.models.cfp import CfP
+from eventyay.base.models.type import SubmissionType
 
 
 @pytest.fixture
@@ -119,6 +121,23 @@ def test_startpage_keeps_featured_when_talks_testmode_false_and_other_true_setti
     assert upcoming.status_code == 200
     upcoming_names = [str(e.name) for e in upcoming.context['events']]
     assert 'Featured Event' in upcoming_names
+
+
+@pytest.mark.django_db
+def test_upcoming_cfp_open_filter_respects_session_type_deadlines(startpage_events, client):
+    _, _, e_upcoming, _ = startpage_events
+    with scopes_disabled():
+        cfp = CfP.objects.filter(event=e_upcoming).first()
+        cfp.deadline = now() - timedelta(days=1)
+        cfp.save()
+        for name in ('Lightning Talk', 'Workshop'):
+            SubmissionType.objects.create(event=e_upcoming, name=name, deadline=now() + timedelta(days=7))
+        assert CfP.objects.get(event=e_upcoming).is_open
+
+    response = client.get('/upcoming/?cfp=open')
+    assert response.status_code == 200
+    names = [str(e.name) for e in response.context['events']]
+    assert names.count('Upcoming Event') == 1
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Resolves #5577

**Description**
Resolves an issue where events incorrectly disappear from the public "Open calls for proposals" list (`/upcoming/?cfp=open`) when their main CfP deadline passes, even if individual session types (like "Lightning Talk") still have an open deadline.

**Changes made**
- Updated the `startpage.py` filter query to include `submission_types__deadline`, mirroring the exact logic used in `CfP.is_open` and the admin dashboard.
- Added `.distinct()` to the query to ensure events aren't duplicated if multiple session types are open at once.
- Added a regression test `test_upcoming_cfp_open_filter_respects_session_type_deadlines` covering both the visibility bug and the potential duplicate card issue.


- Evidence / Screenshots: 

- Before fix:

<img width="1900" height="862" alt="Image" src="https://github.com/user-attachments/assets/ac9bd62a-dd2f-471f-8d37-1690bf53e489" />

- After fix:

<img width="1901" height="863" alt="Image" src="https://github.com/user-attachments/assets/e3b362b7-a2ed-4802-94ab-223cd5cde7c5" />
## Summary by Sourcery

Respect session-type deadlines when filtering the public list of events with open calls for proposals.

Bug Fixes:
- Keep events visible in the public open-CfP list when any session type has an active submission deadline, even after the general CfP deadline expires.
- Prevent events with multiple open session types from appearing more than once in the filtered list.

Tests:
- Add regression coverage for session-type deadline visibility and duplicate event prevention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “open call for proposals” event filter to include events with active submission-type deadlines.
  * Prevented duplicate events from appearing in filtered results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->