### PR TITLE
fix(presale): hide non-public events from start page, past, and followed events

### DIFF
--- a/app/eventyay/presale/views/startpage.py
+++ b/app/eventyay/presale/views/startpage.py
@@ -77,7 +77,7 @@ class StartPageView(TemplateView):
             base_qs = Event.exclude_talks_testmode(
                 Event.objects.select_related('organizer')
                 .prefetch_related('_settings_objects')
-                .filter(live=True, testmode=False)
+                .filter(live=True, is_public=True, testmode=False)
             )
             future_filter = Q(date_to__gte=today_datetime) | Q(date_to__isnull=True, date_from__gte=today_datetime)
             past_filter = Q(date_to__lt=today_datetime) | Q(date_to__isnull=True, date_from__lt=today_datetime)
@@ -191,7 +191,7 @@ class PastEventsView(PaginationMixin, ListView):
         return Event.exclude_talks_testmode(
             Event.objects.select_related('organizer')
             .prefetch_related('_settings_objects')
-            .filter(live=True)
+            .filter(live=True, is_public=True)
             .filter(Q(startpage_visible=True) | Q(startpage_featured=True))
             .filter(Q(date_to__lt=today_datetime) | Q(date_to__isnull=True, date_from__lt=today_datetime))
             .filter(testmode=False)
@@ -226,6 +226,7 @@ class FollowedEventsView(TemplateView):
                 Event.objects.filter(
                     organizer=org,
                     live=True,
+                    is_public=True,
                 )
                 .filter(Q(startpage_visible=True) | Q(startpage_featured=True))
                 .filter(Q(date_to__gte=today_datetime) | Q(date_to__isnull=True, date_from__gte=today_datetime))

--- a/app/tests/tickets/presale/test_startpage_optimization.py
+++ b/app/tests/tickets/presale/test_startpage_optimization.py
@@ -4,7 +4,7 @@ import pytest
 from django.utils.timezone import now
 from django_scopes import scopes_disabled
 
-from eventyay.base.models import Event, Organizer
+from eventyay.base.models import Event, Organizer, OrganizerFollower, User
 
 
 @pytest.fixture
@@ -131,3 +131,85 @@ def test_startpage_hides_events_with_talks_testmode_true(startpage_events, clien
     assert response.status_code == 200
     names = [str(e.name) for e in response.context['featured_events']]
     assert 'Featured Event' not in names
+
+
+@pytest.mark.django_db
+def test_startpage_hides_non_public_events(startpage_events, client):
+    _, e_featured, e_upcoming, e_past = startpage_events
+    with scopes_disabled():
+        e_featured.is_public = False
+        e_featured.save(update_fields=['is_public'])
+        e_upcoming.is_public = False
+        e_upcoming.save(update_fields=['is_public'])
+        e_past.is_public = False
+        e_past.save(update_fields=['is_public'])
+
+    response = client.get('/')
+    assert response.status_code == 200
+    featured_names = [str(e.name) for e in response.context['featured_events']]
+    upcoming_names = [str(e.name) for e in response.context['upcoming_events']]
+    past_names = [str(e.name) for e in response.context['past_events']]
+
+    assert 'Featured Event' not in featured_names
+    assert 'Upcoming Event' not in upcoming_names
+    assert 'Past Event' not in past_names
+
+
+@pytest.mark.django_db
+def test_past_events_page_hides_non_public_events(startpage_events, client):
+    o, _, _, e_past = startpage_events
+    with scopes_disabled():
+        Event.objects.create(
+            organizer=o,
+            name='Private Past Event',
+            slug='past-private',
+            date_from=now() - timedelta(days=10),
+            date_to=now() - timedelta(days=9),
+            live=True,
+            is_public=False,
+            startpage_visible=True,
+            startpage_featured=False,
+        )
+
+    response = client.get('/past/')
+    assert response.status_code == 200
+    event_names = [str(e.name) for e in response.context['events']]
+    assert 'Past Event' in event_names
+    assert 'Private Past Event' not in event_names
+
+
+@pytest.mark.django_db
+def test_followed_events_page_hides_non_public_events(startpage_events, client):
+    o, _, _, _ = startpage_events
+    with scopes_disabled():
+        user = User.objects.create_user('follower@example.com', 'testpass123')
+        OrganizerFollower.objects.create(user=user, organizer=o)
+        Event.objects.create(
+            organizer=o,
+            name='Private Followed Event',
+            slug='followed-private',
+            date_from=now() + timedelta(days=5),
+            live=True,
+            is_public=False,
+            startpage_visible=True,
+        )
+        Event.objects.create(
+            organizer=o,
+            name='Public Followed Event',
+            slug='followed-public',
+            date_from=now() + timedelta(days=6),
+            live=True,
+            is_public=True,
+            startpage_visible=True,
+        )
+
+    client.force_login(user)
+    response = client.get('/followed-events/')
+    assert response.status_code == 200
+    all_names = [
+        str(e.name)
+        for group in response.context['organizer_groups']
+        for e in group['events']
+    ]
+    assert 'Public Followed Event' in all_names
+    assert 'Private Followed Event' not in all_names


### PR DESCRIPTION
## Description
Fixes #5591

When an organizer turns off **"Show in search results and lists"** (`Event.is_public = False`), the event was correctly hidden from `/upcoming/`, search results, and organizer profile pages, but it was still appearing on the public start page (`/`, under Featured/Upcoming/Past/Followed), on `/past/`, and on `/followed-events/`.

This PR adds `is_public=True` filtering to the missing event querysets in `app/eventyay/presale/views/startpage.py`:
1. `StartPageView.get_context_data`: Added `is_public=True` to `base_qs`, ensuring non-public events are hidden from Featured, Upcoming, Past, and Followed sections on the homepage.
2. `PastEventsView.get_queryset`: Added `is_public=True` to the `/past/` event list queryset.
3. `FollowedEventsView.get_context_data`: Added `is_public=True` to the `/followed-events/` queryset.

## Automated Verification
- Added 3 regression unit tests in `app/tests/tickets/presale/test_startpage_optimization.py`:
  - `test_startpage_hides_non_public_events`: verifies events with `is_public=False` do not appear in startpage sections (featured, upcoming, past).
  - `test_past_events_page_hides_non_public_events`: verifies non-public events do not appear on `/past/`.
  - `test_followed_events_page_hides_non_public_events`: verifies non-public events do not appear on `/followed-events/`.
- Ran full test suite for `test_startpage_optimization.py` (8/8 tests passing).
- Ran Django system checks (`python manage.py check` - 0 issues).

## Demonstration & Proof:

### Terminal Recording (Video Demo)
![Startpage Non-Public Events Filter Video Demonstration](https://raw.githubusercontent.com/Pcmhacker-piro/eventyay/assets-pr-5593/startpage_non_public_events_demo.gif)

### Verification Screenshot
![Verification Test Results](https://raw.githubusercontent.com/Pcmhacker-piro/eventyay/assets-pr-5593/startpage_non_public_events_proof.png)
