### PR TITLE
feat(presale): mark ongoing events on the start page cards

### DIFF
--- a/app/eventyay/base/models/event.py
+++ b/app/eventyay/base/models/event.py
@@ -313,6 +313,13 @@ class EventMixin:
         return not self.presale_has_ended
 
     @property
+    def is_ongoing(self):
+        """
+        Is true, when the event has started and has not yet ended.
+        """
+        return self.date_from <= now() <= self.date_to
+
+    @property
     def event_microdata(self):
         import json
 

--- a/app/eventyay/presale/templates/pretixpresale/events/upcoming.html
+++ b/app/eventyay/presale/templates/pretixpresale/events/upcoming.html
@@ -3,6 +3,8 @@
 {% block page_title %}
   {% if cfp_open_filter %}
     {% trans "Open calls for proposals" %}
+  {% elif has_ongoing %}
+    {% trans "Upcoming and Ongoing Events" %}
   {% else %}
     {% trans "Upcoming Events" %}
   {% endif %}
@@ -17,10 +19,12 @@
 </a>
 {% endblock %}
 {% block content %}
-<section class="startpage-events" aria-label="{% if cfp_open_filter %}{% trans 'Open calls for proposals' %}{% else %}{% trans 'Upcoming events' %}{% endif %}">
+<section class="startpage-events" aria-label="{% if cfp_open_filter %}{% trans 'Open calls for proposals' %}{% elif has_ongoing %}{% trans 'Upcoming and ongoing events' %}{% else %}{% trans 'Upcoming events' %}{% endif %}">
   <h2>
     {% if cfp_open_filter %}
       {% trans "Open calls for proposals" %}
+    {% elif has_ongoing %}
+      {% trans "Upcoming and Ongoing Events" %}
     {% else %}
       {% trans "Upcoming Events" %}
     {% endif %}

--- a/app/eventyay/presale/templates/pretixpresale/includes/startpage_event_card.html
+++ b/app/eventyay/presale/templates/pretixpresale/includes/startpage_event_card.html
@@ -14,6 +14,9 @@
     data-event-url="{{ event_url }}"
     data-event-image="{{ event_image_url|default:''|escape }}"
 >
+    {% if event.is_ongoing %}
+        <span class="startpage-event-ongoing">{% trans "Ongoing" %}</span>
+    {% endif %}
     <a class="startpage-event-media" href="{{ event_url }}">
         {% if event_image_url %}
             <img src="{{ event_image_url }}"

--- a/app/eventyay/presale/templates/pretixpresale/startpage.html
+++ b/app/eventyay/presale/templates/pretixpresale/startpage.html
@@ -78,9 +78,14 @@
                 </div>
             </section>
         {% endif %}
-        <section class="startpage-events" aria-label="{% trans "Upcoming events" %}">
+        {% if upcoming_has_ongoing %}
+            {% trans "Upcoming and ongoing events" as upcoming_heading %}
+        {% else %}
+            {% trans "Upcoming events" as upcoming_heading %}
+        {% endif %}
+        <section class="startpage-events" aria-label="{{ upcoming_heading }}">
             <div class="startpage-section-header">
-                <h2>{% trans "Upcoming events" %}</h2>
+                <h2>{{ upcoming_heading }}</h2>
                 <a class="btn btn-link hidden-xs hidden-sm" href="{% url 'presale:events.upcoming' %}">{% trans "View all upcoming events" %}</a>
             </div>
             <div class="startpage-event-list">

--- a/app/eventyay/presale/views/startpage.py
+++ b/app/eventyay/presale/views/startpage.py
@@ -96,6 +96,7 @@ class StartPageView(TemplateView):
 
             ctx['featured_events'] = list(featured_qs)
             ctx['upcoming_events'] = list(upcoming_qs)
+            ctx['upcoming_has_ongoing'] = any(event.is_ongoing for event in ctx['upcoming_events'])
             ctx['past_events'] = list(past_qs)
 
             followed_upcoming_events = []
@@ -175,6 +176,7 @@ class UpcomingEventsView(PaginationMixin, ListView):
         ctx = super().get_context_data(**kwargs)
         ctx['pagination_sizes'] = [20, 50, 100]
         ctx['cfp_open_filter'] = self.request.GET.get('cfp') == 'open'
+        ctx['has_ongoing'] = any(event.is_ongoing for event in ctx['events'])
         ctx.update(_common_base_context(self.request))
         return ctx
 

--- a/app/eventyay/static/pretixpresale/scss/startpage.scss
+++ b/app/eventyay/static/pretixpresale/scss/startpage.scss
@@ -521,12 +521,38 @@ body.startpage-search-results-page #main-card {
   flex-direction: column;
   height: 100%;
   overflow: hidden;
+  position: relative;
   transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .startpage-event-card:hover {
   transform: translateY(-4px);
   box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+}
+
+.startpage-event-ongoing {
+  background: #db2828;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 700;
+  left: -3.2em;
+  letter-spacing: 0.02em;
+  line-height: 1.5;
+  padding: 0.35em 0;
+  pointer-events: none;
+  position: absolute;
+  text-align: center;
+  top: 1.7em;
+  transform: rotate(-45deg);
+  width: 12em;
+  z-index: 1;
+}
+
+html.rtl .startpage-event-ongoing {
+  left: auto;
+  right: -3.2em;
+  transform: rotate(45deg);
 }
 
 

--- a/app/tests/tickets/base/test_models.py
+++ b/app/tests/tickets/base/test_models.py
@@ -2507,6 +2507,23 @@ class EventTest(TestCase):
         assert not event.presale_is_running
 
     @classscope(attr='organizer')
+    def test_is_ongoing(self):
+        event = Event.objects.create(
+            organizer=self.organizer,
+            name='Download',
+            slug='download',
+            date_from=now() + timedelta(hours=1),
+            date_to=now() + timedelta(days=1),
+        )
+        assert not event.is_ongoing
+
+        event.date_from = now() - timedelta(hours=1)
+        assert event.is_ongoing
+
+        event.date_to = now() - timedelta(minutes=1)
+        assert not event.is_ongoing
+
+    @classscope(attr='organizer')
     def test_active_quotas_annotation(self):
         event = Event.objects.create(organizer=self.organizer, name='Download', slug='download', date_from=now())
         q = Quota.objects.create(event=event, name='Quota', size=2)

--- a/app/tests/tickets/presale/test_startpage_ongoing.py
+++ b/app/tests/tickets/presale/test_startpage_ongoing.py
@@ -1,0 +1,100 @@
+from datetime import timedelta
+
+import pytest
+from django.utils.timezone import localtime, now
+from django_scopes import scopes_disabled
+
+from eventyay.base.models import Event, Organizer
+
+
+SASH = 'class="startpage-event-ongoing"'
+
+
+def create_event(organizer, slug, date_from, date_to):
+    return Event.objects.create(
+        organizer=organizer,
+        name=slug,
+        slug=slug,
+        date_from=date_from,
+        date_to=date_to,
+        live=True,
+        is_public=True,
+        startpage_visible=True,
+    )
+
+
+def card_for(content, slug):
+    return next(card for card in content.split('<article')[1:] if f'/{slug}/' in card)
+
+
+@pytest.fixture
+def organizer():
+    with scopes_disabled():
+        return Organizer.objects.create(name='Test Organizer', slug='test-org')
+
+
+@pytest.fixture
+def upcoming_event(organizer):
+    with scopes_disabled():
+        return create_event(organizer, 'upcoming', now() + timedelta(days=10), now() + timedelta(days=12))
+
+
+@pytest.fixture
+def ongoing_event(organizer):
+    with scopes_disabled():
+        return create_event(organizer, 'ongoing', now() - timedelta(days=2), now() + timedelta(days=2))
+
+
+@pytest.mark.django_db
+def test_startpage_marks_only_ongoing_events(client, ongoing_event, upcoming_event):
+    content = client.get('/').content.decode()
+
+    assert SASH in card_for(content, 'ongoing')
+    assert SASH not in card_for(content, 'upcoming')
+    assert '<h2>Upcoming and ongoing events</h2>' in content
+
+
+@pytest.mark.django_db
+def test_startpage_keeps_upcoming_heading_without_ongoing_events(client, upcoming_event):
+    content = client.get('/').content.decode()
+
+    assert SASH not in content
+    assert '<h2>Upcoming events</h2>' in content
+
+
+@pytest.mark.django_db
+def test_startpage_does_not_mark_event_that_ended_today(client, organizer):
+    current = now()
+    midnight = localtime(current).replace(hour=0, minute=0, second=0, microsecond=0)
+    with scopes_disabled():
+        create_event(organizer, 'ended-today', midnight, midnight + (current - midnight) / 2)
+
+    content = client.get('/').content.decode()
+
+    assert SASH not in card_for(content, 'ended-today')
+    assert '<h2>Upcoming events</h2>' in content
+
+
+@pytest.mark.django_db
+def test_upcoming_page_heading_follows_ongoing_events(client, ongoing_event, upcoming_event):
+    response = client.get('/upcoming/')
+    content = response.content.decode()
+
+    assert response.context['has_ongoing']
+    assert 'Upcoming and Ongoing Events' in content
+    assert SASH in card_for(content, 'ongoing')
+
+    with scopes_disabled():
+        Event.objects.filter(pk=ongoing_event.pk).update(
+            date_from=now() + timedelta(days=3), date_to=now() + timedelta(days=4)
+        )
+
+    assert not client.get('/upcoming/').context['has_ongoing']
+
+
+@pytest.mark.django_db
+def test_upcoming_page_keeps_cfp_heading_with_ongoing_events(client, ongoing_event):
+    content = client.get('/upcoming/?cfp=open').content.decode()
+
+    assert 'Open calls for proposals' in content
+    assert 'Upcoming and Ongoing Events' not in content


### PR DESCRIPTION
## What

Event cards now carry a red "Ongoing" sash while the event is running.
The upcoming heading reads "Upcoming and ongoing events" when one of the listed events is ongoing, and stays "Upcoming events" otherwise.

## Why

Fixes #4552.

An event that is happening right now is listed under "Upcoming events" and looks exactly like one that is weeks away.
This follows Saksham's direction in the issue: no new section, a sash on the card, and the heading only changes when there is something ongoing.

## How

- `EventMixin.is_ongoing` is true while `date_from <= now <= date_to`. `date_to` is never empty once saved, because `Event.save()` fills it with `date_from + 24h`.
- The sash lives in the shared `startpage_event_card.html`, so it shows everywhere that card is used: the start page sections, `/upcoming/`, `/followed/` and search results.
- The start page heading and the `/upcoming/` title switch on the events actually listed. "Featured events" and the followed-organizers heading are unchanged.
- The sash uses the brand red `#db2828` with white text (4.8:1), ignores pointer events so the image link underneath stays clickable, and mirrors to the top-right corner for RTL.

An event that ended earlier today still appears under "Upcoming events", because the list is cut at midnight rather than at the current time.
It correctly gets no sash, but it is still listed; that is a separate change to the list queries and is left out of this PR.

## Before

<img width="2459" height="1529" alt="image" src="https://github.com/user-attachments/assets/a09dedb9-0422-4f4f-bc73-3d87d03092a2" />

## After 

<img width="1434" height="897" alt="image" src="https://github.com/user-attachments/assets/2ca4e01d-aa7b-4a6c-a229-2932905afde5" />

## Testing

Added `app/tests/tickets/presale/test_startpage_ongoing.py`:

- `test_startpage_marks_only_ongoing_events`: the ongoing card gets the sash, the upcoming one does not, and the heading reads "Upcoming and ongoing events".
- `test_startpage_keeps_upcoming_heading_without_ongoing_events`: no sash and the plain "Upcoming events" heading when nothing is ongoing.
- `test_startpage_does_not_mark_event_that_ended_today`: an event that finished earlier today is still listed, but gets no sash.
- `test_upcoming_page_heading_follows_ongoing_events`: `/upcoming/` switches its heading, and switches back once the event is no longer ongoing.
- `test_upcoming_page_keeps_cfp_heading_with_ongoing_events`: `/upcoming/?cfp=open` keeps "Open calls for proposals".

Added `EventTest::test_is_ongoing` to `app/tests/tickets/base/test_models.py`, covering an event before it starts, while it runs, and after it ends.

All six pass.
Three of them fail on `dev`: the sash test, the `/upcoming/` heading test and `test_is_ongoing`.
The other three are guards against false positives, so they pass on both.

I also ran `tests/tickets/presale`, `tests/stable` and `tests/tickets/base/test_models.py` on `dev` and on this branch.
The set of failing tests is identical, apart from the three new tests above.

Checked in the browser at 1440, 900 and 390 px wide, over light, dark and red images, and in Arabic, where the sash moves to the top-right corner.

## Summary by Sourcery

Highlight ongoing events on event cards and distinguish them in relevant headings.

New Features:
- Mark currently running events with an “Ongoing” sash across shared event cards.
- Update start page and upcoming page headings when listed events are ongoing.

Enhancements:
- Add an event-level ongoing status based on its start and end times.
- Support RTL positioning and accessible clickable cards for the ongoing sash.

Tests:
- Add coverage for ongoing status boundaries and start page/upcoming page display behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ongoing events are now identified based on their start and end times.
  * Event cards display an “Ongoing” badge for events currently in progress.
  * Start pages and upcoming-event pages now use “Upcoming and Ongoing Events” headings when applicable.
  * Event ribbons support right-to-left layouts.
* **Bug Fixes**
  * Events that have ended are no longer presented as ongoing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->