### PR TITLE
fix(cfP): file retention on form validation failures

### DIFF
--- a/app/eventyay/cfp/flow.py
+++ b/app/eventyay/cfp/flow.py
@@ -318,11 +318,20 @@ class FormFlowStep(TemplateFlowStep):
             if field.endswith('_files'):
                 for f in file_list:
                     existing_files = files.getlist(field)
-                    is_dup = any(
-                        getattr(existing_file, 'name', None) == getattr(f, 'name', None) and 
-                        getattr(existing_file, 'size', None) == getattr(f, 'size', None) 
-                        for existing_file in existing_files
-                    )
+                    is_dup = False
+                    for existing_file in existing_files:
+                        if getattr(existing_file, 'name', None) == getattr(f, 'name', None) and \
+                           getattr(existing_file, 'size', None) == getattr(f, 'size', None):
+                            
+                            f_content = f.read()
+                            existing_content = existing_file.read()
+                            f.seek(0)
+                            existing_file.seek(0)
+                            
+                            if f_content == existing_content:
+                                is_dup = True
+                                break
+
                     if not is_dup:
                         files.appendlist(field, f)
             else:
@@ -391,6 +400,13 @@ class FormFlowStep(TemplateFlowStep):
                                 current = [current]
                             existing[field] = current + new_entries
                         else:
+                            old_entry = existing.get(field)
+                            if old_entry and isinstance(old_entry, dict) and 'tmp_name' in old_entry:
+                                try:
+                                    self.file_storage.delete(old_entry['tmp_name'])
+                                except Exception:
+                                    pass
+                            
                             existing[field] = new_entries if len(new_entries) > 1 else new_entries[0]
                             # Inject initial data so the widget can render the "Currently: link"
                             if hasattr(form, 'initial'):
@@ -827,6 +843,13 @@ class ProfileStep(GenericFlowStep, FormFlowStep):
                                 current = [current]
                             existing[field] = current + new_entries
                         else:
+                            old_entry = existing.get(field)
+                            if old_entry and isinstance(old_entry, dict) and 'tmp_name' in old_entry:
+                                try:
+                                    self.file_storage.delete(old_entry['tmp_name'])
+                                except Exception:
+                                    pass
+                            
                             existing[field] = new_entries if len(new_entries) > 1 else new_entries[0]
                             if hasattr(form, 'initial'):
                                 form.initial[field] = SimpleNamespace(

--- a/app/eventyay/cfp/flow.py
+++ b/app/eventyay/cfp/flow.py
@@ -317,7 +317,14 @@ class FormFlowStep(TemplateFlowStep):
         for field, file_list in self.request.FILES.lists():
             if field.endswith('_files'):
                 for f in file_list:
-                    files.appendlist(field, f)
+                    existing_files = files.getlist(field)
+                    is_dup = any(
+                        getattr(existing_file, 'name', None) == getattr(f, 'name', None) and 
+                        getattr(existing_file, 'size', None) == getattr(f, 'size', None) 
+                        for existing_file in existing_files
+                    )
+                    if not is_dup:
+                        files.appendlist(field, f)
             else:
                 files.setlist(field, file_list)
 
@@ -355,8 +362,51 @@ class FormFlowStep(TemplateFlowStep):
             prev_url = self.get_prev_url(request)
             return redirect(prev_url) if prev_url else redirect(request.path)
 
-        # For "submit" and "draft" actions, validate as before
         if not form.is_valid():
+            # Merge any newly uploaded files into the session and remove session
+            # files from form.files so the widgets fall back to rendering `initial`
+            # data (which contains the URLs for the 'Currently: ...' links).
+            if form.files:
+                existing = self.cfp_session['files'].get(self.identifier, {})
+                for field, field_files in list(form.files.lists()):
+                    new_uploads = []
+                    new_entries = []
+                    for field_file in field_files:
+                        if getattr(field_file, 'is_session_file', False):
+                            continue
+                        tmp_filename = self.file_storage.save(field_file.name, field_file)
+                        new_entries.append({
+                            'tmp_name': tmp_filename,
+                            'name': field_file.name,
+                            'content_type': field_file.content_type,
+                            'size': field_file.size,
+                            'charset': field_file.charset,
+                        })
+                        new_uploads.append(field_file)
+                    
+                    if new_entries:
+                        if field.endswith('_files'):
+                            current = existing.get(field, [])
+                            if not isinstance(current, list):
+                                current = [current]
+                            existing[field] = current + new_entries
+                        else:
+                            existing[field] = new_entries if len(new_entries) > 1 else new_entries[0]
+                            # Inject initial data so the widget can render the "Currently: link"
+                            if hasattr(form, 'initial'):
+                                form.initial[field] = SimpleNamespace(
+                                    name=new_entries[0]['name'],
+                                    url=self.file_storage.url(new_entries[0]['tmp_name'])
+                                )
+                            # Invalidate the bound field cache so it picks up the new initial data
+                            if hasattr(form, '_bound_fields_cache'):
+                                form._bound_fields_cache.pop(field, None)
+                    
+                    if new_uploads:
+                        form.files.setlist(field, new_uploads)
+                    else:
+                        del form.files[field]
+                self.cfp_session['files'][self.identifier] = existing
             warning_messages = getattr(form, 'warning_messages', None) or []
             for warning in filter(None, warning_messages):
                 messages.warning(self.request, warning)
@@ -749,6 +799,48 @@ class ProfileStep(GenericFlowStep, FormFlowStep):
         formset_valid = self.social_media_formset_is_valid(formset)
 
         if not form_valid or not formset_valid:
+            # Merge any newly uploaded files into the session and remove session
+            # files from form.files so the widgets fall back to rendering `initial`
+            # data (which contains the URLs for the 'Currently: ...' links).
+            if form.files:
+                existing = self.cfp_session['files'].get(self.identifier, {})
+                for field, field_files in list(form.files.lists()):
+                    new_uploads = []
+                    new_entries = []
+                    for field_file in field_files:
+                        if getattr(field_file, 'is_session_file', False):
+                            continue
+                        tmp_filename = self.file_storage.save(field_file.name, field_file)
+                        new_entries.append({
+                            'tmp_name': tmp_filename,
+                            'name': field_file.name,
+                            'content_type': field_file.content_type,
+                            'size': field_file.size,
+                            'charset': field_file.charset,
+                        })
+                        new_uploads.append(field_file)
+                    
+                    if new_entries:
+                        if field.endswith('_files'):
+                            current = existing.get(field, [])
+                            if not isinstance(current, list):
+                                current = [current]
+                            existing[field] = current + new_entries
+                        else:
+                            existing[field] = new_entries if len(new_entries) > 1 else new_entries[0]
+                            if hasattr(form, 'initial'):
+                                form.initial[field] = SimpleNamespace(
+                                    name=new_entries[0]['name'],
+                                    url=self.file_storage.url(new_entries[0]['tmp_name'])
+                                )
+                            if hasattr(form, '_bound_fields_cache'):
+                                form._bound_fields_cache.pop(field, None)
+                    
+                    if new_uploads:
+                        form.files.setlist(field, new_uploads)
+                    else:
+                        del form.files[field]
+                self.cfp_session['files'][self.identifier] = existing
             warning_messages = getattr(form, 'warning_messages', None) or []
             for warning in filter(None, warning_messages):
                 messages.warning(self.request, warning)

--- a/app/eventyay/static/cfp/js/formAutoSave.js
+++ b/app/eventyay/static/cfp/js/formAutoSave.js
@@ -164,10 +164,18 @@ function restoreFormData() {
         }
 
         // If all saved fields match current values AND we checked some fields,
-        // it means the form was successfully submitted - clear sessionStorage
+        // it means the form was successfully submitted - clear sessionStorage.
+        // BUT: if there are validation errors on the page, the server just echoed
+        // back our POST data — don't clear, or the data will be lost on refresh.
         if (allFieldsMatch && checkedFields > 0) {
-            clearFormData();
-            return;
+            const hasValidationErrors =
+                document.querySelector('.alert-danger') ||
+                document.querySelector('.has-error') ||
+                document.querySelector('.is-invalid');
+            if (!hasValidationErrors) {
+                clearFormData();
+                return;
+            }
         }
 
         // Otherwise, restore from sessionStorage


### PR DESCRIPTION
**Fixes:** #5596 

## Description
This PR resolves data-loss and file retention bugs in the CFP form that occur when a user fails validation due to missing mandatory fields.

### Changes made:
* **Prevented text data loss:** Added a check in `formAutoSave.js` to ensure auto-saved local storage is not cleared on page load if Django validation errors (`.alert-danger`) are present on the page.
* **Fixed "lost" image illusion:** Updated `GenericFlowStep.post()` to properly inject session file metadata into `form.initial` and invalidate the Django `_bound_fields_cache`. This allows the `ClearableFileInput` widget to correctly render the `Currently: <filename>` link instead of an empty file input on validation failures.
* **Resolved duplicate slide errors:** Modified `get_form()` to deduplicate incoming multi-file uploads (by name and size) against existing session files. This prevents browsers that natively retain form state from silently submitting duplicates and incorrectly triggering the `You can add at most 1 slide entries` error.

## Testing Instructions
1. Fill out the CFP Session/Profile form.
2. Upload a Session Image and a Slide file.
3. Intentionally leave a mandatory text field blank and click "Continue".
4. **Verify:** Text inputs are retained, the image field displays `Currently: <filename>`, and clicking "Continue" a second time does not throw a slide limit error.



https://github.com/user-attachments/assets/e1820be8-3047-444e-9369-71465d6a7721

## Summary by Sourcery

Preserve CFP form data and uploads when validation fails, while preventing duplicate file submissions from causing spurious validation errors.

Bug Fixes:
- Preserve auto-saved form data when validation errors are displayed, preventing text input loss on refresh.
- Retain uploaded files across CFP validation failures and restore their visible filenames in file fields.
- Prevent duplicate multi-file submissions from triggering erroneous slide-count validation errors.

Enhancements:
- Improve CFP form handling for session-backed uploads and invalid submissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File uploads are now preserved when form validation fails, allowing users to review and resubmit them without re-uploading.
  * Duplicate uploads are filtered out when their names and sizes match existing uploads.
  * Replacing a previously uploaded single file now correctly updates the saved upload.
  * Saved form data is retained when validation errors are present, preventing accidental loss of entered information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->