### PR TITLE
feat(presale): add ongoing status badge and dynamic section title for active events

### DIFF
--- a/app/eventyay/base/models/event.py
+++ b/app/eventyay/base/models/event.py
@@ -279,6 +279,23 @@ class EventMixin:
             return self.presale_end
 
     @property
+    def is_ongoing(self) -> bool:
+        """
+        Is true if the current time falls within the event duration.
+        """
+        if not self.date_from:
+            return False
+        current_time = now()
+        if self.date_to:
+            return self.date_from <= current_time <= self.date_to
+        else:
+            tz = self.timezone
+            return (
+                self.date_from <= current_time
+                and current_time.astimezone(tz).date() <= self.date_from.astimezone(tz).date()
+            )
+
+    @property
     def presale_has_ended(self):
         """
         Is true, when ``presale_end`` is set and in the past.
@@ -931,6 +948,14 @@ class Event(
             return self.presale_end and now() > self.presale_end
         else:
             return super().presale_has_ended
+
+    @property
+    def is_ongoing(self) -> bool:
+        if self.has_subevents:
+            if hasattr(self, '_prefetched_objects_cache') and 'subevents' in self._prefetched_objects_cache:
+                return any(s.is_ongoing for s in self.subevents.all() if s.active)
+            return any(s.is_ongoing for s in self.subevents.filter(active=True))
+        return super().is_ongoing
 
     def delete_all_orders(self, really=False):
         from .orders import OrderFee, OrderPayment, OrderPosition, OrderRefund

--- a/app/eventyay/presale/templates/pretixpresale/events/upcoming.html
+++ b/app/eventyay/presale/templates/pretixpresale/events/upcoming.html
@@ -3,6 +3,8 @@
 {% block page_title %}
   {% if cfp_open_filter %}
     {% trans "Open calls for proposals" %}
+  {% elif has_ongoing_events %}
+    {% trans "Upcoming and Ongoing Events" %}
   {% else %}
     {% trans "Upcoming Events" %}
   {% endif %}
@@ -17,10 +19,12 @@
 </a>
 {% endblock %}
 {% block content %}
-<section class="startpage-events" aria-label="{% if cfp_open_filter %}{% trans 'Open calls for proposals' %}{% else %}{% trans 'Upcoming events' %}{% endif %}">
+<section class="startpage-events" aria-label="{% if cfp_open_filter %}{% trans 'Open calls for proposals' %}{% elif has_ongoing_events %}{% trans 'Upcoming and ongoing events' %}{% else %}{% trans 'Upcoming events' %}{% endif %}">
   <h2>
     {% if cfp_open_filter %}
       {% trans "Open calls for proposals" %}
+    {% elif has_ongoing_events %}
+      {% trans "Upcoming and Ongoing Events" %}
     {% else %}
       {% trans "Upcoming Events" %}
     {% endif %}

--- a/app/eventyay/presale/templates/pretixpresale/includes/startpage_event_card.html
+++ b/app/eventyay/presale/templates/pretixpresale/includes/startpage_event_card.html
@@ -8,12 +8,17 @@
 {% with event.preview_image_url_small as event_image_url_small %}
 {% with event.social_image_signature as share_image_signature %}
 <article
-    class="startpage-event-card"
+    class="startpage-event-card{% if event.is_ongoing %} is-ongoing{% endif %}"
     data-event-name="{{ event.name|event_localize|escape }}"
     data-event-date="{{ event.get_date_range_display|escape }}"
     data-event-url="{{ event_url }}"
     data-event-image="{{ event_image_url|default:''|escape }}"
 >
+    {% if event.is_ongoing %}
+        <div class="startpage-sash-ribbon" aria-label="{% trans "Ongoing" %}" title="{% trans "Ongoing event" %}">
+            <span>{% trans "Ongoing" %}</span>
+        </div>
+    {% endif %}
     <a class="startpage-event-media" href="{{ event_url }}">
         {% if event_image_url %}
             <img src="{{ event_image_url }}"

--- a/app/eventyay/presale/templates/pretixpresale/startpage.html
+++ b/app/eventyay/presale/templates/pretixpresale/startpage.html
@@ -78,9 +78,9 @@
                 </div>
             </section>
         {% endif %}
-        <section class="startpage-events" aria-label="{% trans "Upcoming events" %}">
+        <section class="startpage-events" aria-label="{% if has_ongoing_events %}{% trans "Upcoming and ongoing events" %}{% else %}{% trans "Upcoming events" %}{% endif %}">
             <div class="startpage-section-header">
-                <h2>{% trans "Upcoming events" %}</h2>
+                <h2>{% if has_ongoing_events %}{% trans "Upcoming and ongoing events" %}{% else %}{% trans "Upcoming events" %}{% endif %}</h2>
                 <a class="btn btn-link hidden-xs hidden-sm" href="{% url 'presale:events.upcoming' %}">{% trans "View all upcoming events" %}</a>
             </div>
             <div class="startpage-event-list">

--- a/app/eventyay/presale/views/startpage.py
+++ b/app/eventyay/presale/views/startpage.py
@@ -97,6 +97,7 @@ class StartPageView(TemplateView):
             ctx['featured_events'] = list(featured_qs)
             ctx['upcoming_events'] = list(upcoming_qs)
             ctx['past_events'] = list(past_qs)
+            ctx['has_ongoing_events'] = any(e.is_ongoing for e in ctx['upcoming_events'])
 
             followed_upcoming_events = []
             if self.request.user.is_authenticated:
@@ -175,6 +176,7 @@ class UpcomingEventsView(PaginationMixin, ListView):
         ctx = super().get_context_data(**kwargs)
         ctx['pagination_sizes'] = [20, 50, 100]
         ctx['cfp_open_filter'] = self.request.GET.get('cfp') == 'open'
+        ctx['has_ongoing_events'] = any(e.is_ongoing for e in ctx['events'])
         ctx.update(_common_base_context(self.request))
         return ctx
 

--- a/app/eventyay/static/pretixpresale/scss/startpage.scss
+++ b/app/eventyay/static/pretixpresale/scss/startpage.scss
@@ -521,12 +521,54 @@ body.startpage-search-results-page #main-card {
   flex-direction: column;
   height: 100%;
   overflow: hidden;
+  position: relative;
   transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .startpage-event-card:hover {
   transform: translateY(-4px);
   box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+}
+
+.startpage-sash-ribbon {
+  height: 88px;
+  overflow: hidden;
+  pointer-events: none;
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 88px;
+  z-index: 10;
+
+  span {
+    background-color: var(--color-danger, #db2828);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+    color: #fff;
+    display: block;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    line-height: 1;
+    padding: 6px 0;
+    position: absolute;
+    right: -26px;
+    text-align: center;
+    text-transform: uppercase;
+    top: 20px;
+    transform: rotate(45deg);
+    width: 125px;
+  }
+
+  html.rtl & {
+    left: 0;
+    right: auto;
+
+    span {
+      left: -26px;
+      right: auto;
+      transform: rotate(-45deg);
+    }
+  }
 }
 
 

--- a/app/tests/tickets/presale/test_ongoing_events.py
+++ b/app/tests/tickets/presale/test_ongoing_events.py
@@ -1,0 +1,171 @@
+from datetime import timedelta
+
+import pytest
+from django.utils.timezone import now
+from django_scopes import scopes_disabled
+
+from eventyay.base.models import Event, Organizer, SubEvent
+
+
+@pytest.fixture
+def test_organizer():
+    with scopes_disabled():
+        return Organizer.objects.create(name='Ongoing Org', slug='ongoing-org')
+
+
+@pytest.mark.django_db
+def test_event_is_ongoing_property(test_organizer):
+    current = now()
+    with scopes_disabled():
+        # Ongoing event with date_from and date_to
+        ongoing_event = Event.objects.create(
+            organizer=test_organizer,
+            name='Ongoing Event',
+            slug='ongoing-ev',
+            date_from=current - timedelta(days=2),
+            date_to=current + timedelta(days=2),
+            live=True,
+            is_public=True,
+        )
+        assert ongoing_event.is_ongoing is True
+
+        # Future event
+        future_event = Event.objects.create(
+            organizer=test_organizer,
+            name='Future Event',
+            slug='future-ev',
+            date_from=current + timedelta(days=1),
+            date_to=current + timedelta(days=3),
+            live=True,
+            is_public=True,
+        )
+        assert future_event.is_ongoing is False
+
+        # Past event
+        past_event = Event.objects.create(
+            organizer=test_organizer,
+            name='Past Event',
+            slug='past-ev',
+            date_from=current - timedelta(days=5),
+            date_to=current - timedelta(days=2),
+            live=True,
+            is_public=True,
+        )
+        assert past_event.is_ongoing is False
+
+        # Single-day event today without date_to
+        today_event = Event.objects.create(
+            organizer=test_organizer,
+            name='Today Event',
+            slug='today-ev',
+            date_from=current - timedelta(hours=1),
+            date_to=None,
+            live=True,
+            is_public=True,
+        )
+        assert today_event.is_ongoing is True
+
+        # Single-day event yesterday without date_to
+        yesterday_event = Event.objects.create(
+            organizer=test_organizer,
+            name='Yesterday Event',
+            slug='yesterday-ev',
+            date_from=current - timedelta(days=1, hours=2),
+            date_to=None,
+            live=True,
+            is_public=True,
+        )
+        assert yesterday_event.is_ongoing is False
+
+        # Series event with subevents
+        series_event = Event.objects.create(
+            organizer=test_organizer,
+            name='Series Event',
+            slug='series-ev',
+            date_from=current + timedelta(days=5),
+            has_subevents=True,
+            live=True,
+            is_public=True,
+        )
+        assert series_event.is_ongoing is False
+
+        subevent = SubEvent.objects.create(
+            event=series_event,
+            name='SubEvent 1',
+            date_from=current - timedelta(days=1),
+            date_to=current + timedelta(days=1),
+            active=True,
+        )
+        assert subevent.is_ongoing is True
+        assert series_event.is_ongoing is True
+
+
+@pytest.mark.django_db
+def test_startpage_ongoing_section_header_and_badge(test_organizer, client):
+    current = now()
+    with scopes_disabled():
+        # Only future event initially
+        future_ev = Event.objects.create(
+            organizer=test_organizer,
+            name='Future Conference',
+            slug='future-conf',
+            date_from=current + timedelta(days=10),
+            date_to=current + timedelta(days=12),
+            live=True,
+            is_public=True,
+            startpage_visible=True,
+            startpage_featured=False,
+        )
+
+    # When no ongoing events exist
+    response = client.get('/')
+    assert response.status_code == 200
+    content = response.content.decode('utf-8')
+    assert 'Upcoming events' in content
+    assert 'Upcoming and ongoing events' not in content
+    assert 'startpage-sash-ribbon' not in content
+
+    # Add an ongoing event
+    with scopes_disabled():
+        ongoing_ev = Event.objects.create(
+            organizer=test_organizer,
+            name='Active Live Festival',
+            slug='active-live-festival',
+            date_from=current - timedelta(days=1),
+            date_to=current + timedelta(days=2),
+            live=True,
+            is_public=True,
+            startpage_visible=True,
+            startpage_featured=False,
+        )
+
+    response = client.get('/')
+    assert response.status_code == 200
+    content = response.content.decode('utf-8')
+    assert 'Upcoming and ongoing events' in content
+    assert 'startpage-sash-ribbon' in content
+    assert 'Ongoing' in content
+    assert 'is-ongoing' in content
+
+
+@pytest.mark.django_db
+def test_upcoming_events_page_ongoing_header_and_badge(test_organizer, client):
+    current = now()
+    with scopes_disabled():
+        Event.objects.create(
+            organizer=test_organizer,
+            name='Ongoing Hackathon',
+            slug='ongoing-hackathon',
+            date_from=current - timedelta(hours=5),
+            date_to=current + timedelta(days=2),
+            live=True,
+            is_public=True,
+            startpage_visible=True,
+        )
+
+    response = client.get('/upcoming/')
+    assert response.status_code == 200
+    content = response.content.decode('utf-8')
+    assert 'Upcoming and Ongoing Events' in content
+    assert 'startpage-sash-ribbon' in content
+    assert 'Ongoing' in content


### PR DESCRIPTION
## What does this PR do?
This PR adds an ongoing status indicator for active events and dynamically renames the section header from "Upcoming events" to "Upcoming and ongoing events" when active events are present, addressing [#4552](https://github.com/fossasia/eventyay/issues/4552).

- fixing : #4552

## Changes proposed in this pull request:

### Model Layer (`app/eventyay/base/models/event.py`)
- **`is_ongoing` property on `EventMixin`:** Evaluates whether `now()` falls within event duration (`date_from <= now <= date_to`, or active on `date_from`'s calendar day in event timezone if `date_to` is omitted).
- **Subevents support on `Event`:** Recursively detects whether any active subevents in an event series are ongoing.

### Presentation & Template Layer
- **`startpage_event_card.html`:** Dynamically adds `.is-ongoing` class and renders a corner red sash ribbon (`<div class="startpage-sash-ribbon"><span>Ongoing</span></div>`) on cards for ongoing events.
- **`startpage.html`:** Dynamically swaps section title and aria-label to `"Upcoming and ongoing events"` when at least one ongoing event is present.
- **`upcoming.html`:** Dynamically updates page title and section header to `"Upcoming and Ongoing Events"` when ongoing events exist.
- **`startpage.py`:** Provides `has_ongoing_events` context flag in `StartPageView` and `UpcomingEventsView`.

### Design & Styling (`app/eventyay/static/pretixpresale/scss/startpage.scss`)
- **Corner Sash Ribbon (`.startpage-sash-ribbon`):** Positioned with `overflow: hidden`, `pointer-events: none`, bold uppercase styling using `var(--color-danger, #db2828)`, crisp white typography, and full RTL layout support.

## How to test this:
1. Run automated test suite:
   ```bash
   uv run pytest tests/tickets/presale/test_ongoing_events.py tests/tickets/presale/test_startpage_optimization.py -v
   ```
2. Start development server (`python manage.py runserver`).
3. Create or schedule an event whose date range covers the current time (e.g. start date 2 days ago, end date 2 days in the future).
4. Verify that:
   - On the homepage (`/`), the section header updates to **"Upcoming and ongoing events"**.
   - The active event card displays the prominent red **"Ongoing"** sash in the upper corner.
   - Non-active future events do not display the ribbon.
   - On `/upcoming/`, the header updates to **"Upcoming and Ongoing Events"**.

## Automated Verification:
- Added comprehensive test suite in `app/tests/tickets/presale/test_ongoing_events.py`:
  - `test_event_is_ongoing_property`: tests multi-day ongoing, future, past, single-day, and series subevents.
  - `test_startpage_ongoing_section_header_and_badge`: tests dynamic header renaming and sash badge on homepage.
  - `test_upcoming_events_page_ongoing_header_and_badge`: tests `/upcoming/` page header and card badge.
- Ran all existing and new tests: 8/8 tests passed in `test_ongoing_events.py` and `test_startpage_optimization.py`.
- Ran presale regression suite: 15/15 tests passed in `test_presale.py`.
- System check: `python manage.py check` reports 0 issues.

## Demonstration & Proof:

### Terminal Recording (Video Demo)
![Ongoing Events Status Indicator Video Demonstration](https://raw.githubusercontent.com/Pcmhacker-piro/eventyay/assets-pr-4552/ongoing_events_demo.gif)

### Verification Screenshot
![Verification Test Results](https://raw.githubusercontent.com/Pcmhacker-piro/eventyay/assets-pr-4552/ongoing_events_proof.png)

## Summary by Sourcery
Enhancements:
- Display red corner "Ongoing" status sash on active event cards.
- Dynamically update upcoming events section title to "Upcoming and ongoing events" when active events are present.

## Summary by Sourcery

Highlight currently active events across the start page and upcoming-events listings.

New Features:
- Add ongoing status detection for events, including events with active subevents.
- Display an “Ongoing” badge on active event cards and update upcoming-event headings when ongoing events are present.

Enhancements:
- Expose ongoing-event state to the start page and upcoming-events views with support for featured events and event series.

Tests:
- Add coverage for ongoing-event detection, event series, status badges, and dynamic headings on both event listing pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Ongoing events are now identified across individual and series events.
  - Start pages distinguish between upcoming events and upcoming or ongoing events.
  - Ongoing event cards display an “Ongoing” ribbon and visual styling.
  - Labels and accessibility text reflect when ongoing events are present.

- **Tests**
  - Added coverage for ongoing, upcoming, past, single-day, and series events.
  - Added checks for ongoing-event headings, badges, ribbons, and event listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->